### PR TITLE
kmap_spider v0.0.1

### DIFF
--- a/converter/spiders/kmap_spider.py
+++ b/converter/spiders/kmap_spider.py
@@ -1,0 +1,138 @@
+import json
+
+import scrapy.http
+from playwright.sync_api import sync_playwright
+from scrapy.spiders import CrawlSpider
+
+from converter.constants import Constants
+from converter.items import BaseItemLoader, LomBaseItemloader, LomGeneralItemloader, LomTechnicalItemLoader, \
+    LomLifecycleItemloader, LomEducationalItemLoader, ValuespaceItemLoader, LicenseItemLoader, ResponseItemLoader
+from converter.spiders.base_classes import LomBase
+from converter.util.sitemap import from_xml_response
+
+
+class KMapSpider(CrawlSpider, LomBase):
+    name = "kmap_spider"
+    friendlyName = "KMap.eu"
+    version = "0.0.1"
+    sitemap_urls = [
+        "https://kmap.eu/server/sitemap/Mathematik",
+        "https://kmap.eu/server/sitemap/Physik"
+    ]
+    allowed_domains = ['kmap.eu']
+    playwright_instance = None
+    browser_permanent = None
+
+    def start_requests(self) -> scrapy.Request:
+        for sitemap_url in self.sitemap_urls:
+            yield scrapy.Request(url=sitemap_url, callback=self.parse_sitemap)
+        # opening a headless browser that will hold our individual BrowserContexts when get_json_ld() is called
+        self.playwright_instance = sync_playwright().start()
+        self.browser_permanent = self.playwright_instance.chromium.launch()
+
+    def close(self, reason):
+        # when the spider is done with its crawling process, it should close the playwright- and browser-instance
+        self.browser_permanent.close()
+        self.playwright_instance.stop()
+
+    def parse_sitemap(self, response) -> scrapy.Request:
+        sitemap_items = from_xml_response(response)
+        for sitemap_item in sitemap_items:
+            temp_dict = {
+                'lastModified': sitemap_item.lastmod
+            }
+            yield scrapy.Request(url=sitemap_item.loc, callback=self.parse, cb_kwargs=temp_dict)
+
+    def getId(self, response=None) -> str:
+        return response.url
+
+    def getHash(self, response=None) -> str:
+        pass
+
+    def get_json_ld(self, url_to_crawl) -> dict:
+        # using a Playwright BrowserContext allows us to save time/resources, each get_ld_json call spawns a page (=
+        # headless browser tab) within our BrowserContext (~ browser session),
+        # see: https://playwright.dev/python/docs/core-concepts/
+        context = self.browser_permanent.new_context()
+        page = context.new_page()
+        page.goto(url_to_crawl)
+        json_ld_string: str = page.text_content('//*[@id="ld"]')
+        json_ld = json.loads(json_ld_string)
+        context.close()
+        return json_ld
+
+    def parse(self, response: scrapy.http.Response, **kwargs) -> BaseItemLoader:
+        # print("PARSE METHOD:", response.url)
+        last_modified = kwargs.get("lastModified")
+        json_ld: dict = self.get_json_ld(response.url)
+        # for debug purposes - checking if the json_ld is correct/available:
+        # print("LD_JSON =", json_ld)
+        # print(type(json_ld))
+
+        base = BaseItemLoader()
+        base.add_value('sourceId', response.url)
+        hash_temp = json_ld.get("mainEntity").get("datePublished")
+        hash_temp += self.version
+        base.add_value('hash', hash_temp)
+        base.add_value('lastModified', last_modified)
+        base.add_value('type', Constants.TYPE_MATERIAL)
+        # Thumbnails have their own url path, which can be found in the json+ld:
+        #   "thumbnailUrl": "/snappy/Physik/Grundlagen/Potenzschreibweise"
+        # e.g. for the item https://kmap.eu/app/browser/Physik/Grundlagen/Potenzschreibweise
+        # the thumbnail can be found at https://kmap.eu/snappy/Physik/Grundlagen/Potenzschreibweise
+        thumbnail_path = json_ld.get("mainEntity").get("thumbnailUrl")
+        if thumbnail_path is not None:
+            thumbnail_url = "https://kmap.eu" + thumbnail_path
+            base.add_value('thumbnail', thumbnail_url)
+
+        lom = LomBaseItemloader()
+        general = LomGeneralItemloader()
+        general.add_value('identifier', json_ld.get("mainEntity").get("mainEntityOfPage"))
+        keywords_string: str = json_ld.get("mainEntity").get("keywords")
+        keyword_list = keywords_string.rsplit(", ")
+        general.add_value('keyword', keyword_list)
+        general.add_value('title', json_ld.get("mainEntity").get("name"))
+        general.add_value('description', json_ld.get("mainEntity").get("description"))
+        general.add_value('language', json_ld.get("mainEntity").get("inLanguage"))
+        lom.add_value('general', general.load_item())
+
+        technical = LomTechnicalItemLoader()
+        technical.add_value('format', 'text/html')
+        technical.add_value('location', response.url)
+        lom.add_value('technical', technical.load_item())
+
+        lifecycle = LomLifecycleItemloader()
+        lifecycle.add_value('role', 'publisher')
+        lifecycle.add_value('organization', json_ld.get("mainEntity").get("publisher").get("name"))
+        author_email = json_ld.get("mainEntity").get("publisher").get("email")
+        if author_email is not None:
+            lifecycle.add_value('email', author_email)
+        lifecycle.add_value('url', 'https://kmap.eu/')
+        lifecycle.add_value('date', json_ld.get("mainEntity").get("datePublished"))
+        lom.add_value('lifecycle', lifecycle.load_item())
+
+        educational = LomEducationalItemLoader()
+        lom.add_value('educational', educational.load_item())
+        base.add_value('lom', lom.load_item())
+
+        vs = ValuespaceItemLoader()
+        vs.add_value('discipline', json_ld.get("mainEntity").get("about"))
+        vs.add_value('intendedEndUserRole', json_ld.get("mainEntity").get("audience"))
+        vs.add_value('learningResourceType', json_ld.get("mainEntity").get("learningResourceType"))
+        vs.add_value('price', 'no')
+        vs.add_value('conditionsOfAccess', 'login required for additional features')
+        base.add_value('valuespaces', vs.load_item())
+
+        lic = LicenseItemLoader()
+        lic.add_value('author', json_ld.get("mainEntity").get("author").get("name"))
+        lic.add_value('url', json_ld.get("mainEntity").get("license"))
+        base.add_value('license', lic.load_item())
+
+        permissions = super().getPermissions(response)
+        base.add_value("permissions", permissions.load_item())
+
+        response_loader = ResponseItemLoader()
+        response_loader.add_value("url", response.url)
+        base.add_value("response", response_loader.load_item())
+
+        return base.load_item()

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ itemadapter~=0.2.0
 six~=1.15.0
 certifi~=2020.12.5
 urllib3~=1.25.11
+playwright~=1.12.1


### PR DESCRIPTION
### kmap_spider v0.0.1 is ready for code-review
This is the first time we're using https://playwright.dev/python/ for parsing a single-page-application, which was necessary because the `json+ld`-container is built dynamically client-side without any visible API Requests in the browser network tools.

There'll be a chapter in our GitHub Wiki with starting advice for Playwright, but to understand what Playwright does in my code, these are the corresponding docs:
- https://playwright.dev/python/docs/core-concepts
- https://playwright.dev/python/docs/api/class-page#page-text-content

### Basically the crawler's algorithm works like this:

1. During the start_requests() method open the Playwright process and start one headless Chromium instance 
2. Parse the sitemap for individual urls + the lastmod date
3. Parse the individual entries with scrapy
3.1. get the JSON_LD container with Playwright's help by opening a Playwright BrowserContext (= session); 
_basically each get_json_ld() call has its own "tab" inside the headless browser_
3.2. return the json_ld to the parse() method
4. once the spider is done with all requests, it calls the close() method and shuts down the browser instance + playwright

---
I've squashed the individual commits before doing the PullRequest, here's the summary:
> fix: lifecycle url + email
> code cleanup / fix: lifecycle url
> 
> add: metadata / fix: lifecycle values / code cleanup
> - base: thumbnail, type
> - general: language
> - technical: format
> - lifecycle: role
> - valuespaces: discipline, intendedEndUserRole, learningResourceType, price, conditionsOfAccess
> - license: author, url
> 
> hold only one browser instance open with playwright and use contexts for each request
> - during start_requests() start the playwright instance and one single chromium browser
> - get_json_ld() uses this browser to spawn new tabs
> - close() method is called when the spider is done and closes the browser + playwright instance
> 
> add metadata values and minor code cleanup
> - add general: identifier, lastmod
> - fix general: description
> - add lifecycle:
> -- role: publisher (WIP, might not work in edu-sharing mode)
> -- datePublished
> 
> kmap_spider.py v0.0.1 (WIP!)
> Squashed changelog:
> - add ItemLoaders and potential metadata as ToDos
> - use playwright to fetch the json+ld
> -- since Scrapy can't handle Single-Page-Applications and dynamic content, Playwright for Python hopefully solves that problem for us with a headless chromium browser
> - add get_json_ld method using sync_playwright()
> - add keywords