### PR TITLE
First batch of rudimentary Scrapy Contracts for existing spiders and small fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,9 +15,14 @@ python3 -m venv .venv
 
 `pip3 install -r requirements.txt`
 
-As a last step, set up your config variables by copying the example and modify it if necessary `cp converter/.env.example converter/.env`
+If you have Docker installed, use `docker-compose up` to start up the multi-container for `Splash` and `Pyppeteer`-integration. 
+
+As a last step, set up your config variables by copying the `.env.example`-file and modifying it if necessary: 
+
+`cp converter/.env.example converter/.env`
 
 - A crawler can be run with `scrapy crawl <spider-name>`. It assumes that you have an edu-sharing 6.0 instance in your `.env` settings configured which can accept the data.
+- If a crawler has [Scrapy Spider Contracts](https://docs.scrapy.org/en/latest/topics/contracts.html#spiders-contracts) implemented, you can test those by running `scrapy check <spider-name>`
 
 ## Building a Crawler
 

--- a/converter/.env.example
+++ b/converter/.env.example
@@ -10,14 +10,21 @@ MODE = "csv"
 # csv rows to export from dataset (comma seperated, only used if mode == "csv")
 CSV_ROWS = "lom.general.title,lom.general.description,lom.general.keyword,lom.technical.location,valuespaces.discipline,valuespaces.learningResourceType"
 
+# Splash Integration settings for the local container,
+# for more information, see https://splash.readthedocs.io/en/stable/
 DISABLE_SPLASH = False
 SPLASH_URL = "http://localhost:8050"
 
+# PYPPETEER Integration settings, as needed for the local container (as used in kmap_spider.py)
+# for more information, see: https://github.com/pyppeteer/pyppeteer
+PYPPETEER_WS_ENDPOINT = "ws://localhost:3000"
+
+# Edu-Sharing instance that the crawlers should upload to
 EDU_SHARING_BASE_URL = "http://localhost:8080/edu-sharing/"
 EDU_SHARING_USERNAME = "admin"
 EDU_SHARING_PASSWORD = "admin"
 
-# Don't upload to Edu-Sharing
+# If set to true, don't upload to (above mentioned) Edu-Sharing instance
 DRY_RUN = True
 
 # your youtube api key (required for youtube crawler)

--- a/converter/spiders/ginkgomaps_spider.py
+++ b/converter/spiders/ginkgomaps_spider.py
@@ -16,7 +16,7 @@ class GinkgoMapsSpider(scrapy.Spider, LomBase):
     start_urls = [
         "http://ginkgomaps.com/index_de.html"
     ]
-    version = "0.0.1"  # reflects the structure of Ginkgomaps.com on 2021-06-14
+    version = "0.0.1"  # reflects the structure of Ginkgomaps.com on 2021-10-04
 
     custom_settings = {
         'ROBOTSTXT_OBEY': False,
@@ -106,6 +106,12 @@ class GinkgoMapsSpider(scrapy.Spider, LomBase):
         pass
 
     def get_navigation_urls_first_level(self, response: scrapy.http.Response):
+        """
+
+        Scrapy Contracts:
+        @url http://ginkgomaps.com/index_de.html
+        @returns requests 5
+        """
         url_depth = 1
 
         yield from self.check_for_dead_ends_before_parsing(response)
@@ -125,6 +131,11 @@ class GinkgoMapsSpider(scrapy.Spider, LomBase):
         yield from self.crawl_next_url_level(diff_set, response, url_depth)
 
     def get_navigation_urls_second_level(self, response: scrapy.http.Response):
+        """
+
+        @url http://ginkgomaps.com/landkarten_amerikanische_jungferninseln.html
+        @returns requests 3
+        """
         url_depth = 2
         yield from self.check_for_dead_ends_before_parsing(response)
         temp_set = set()
@@ -143,6 +154,11 @@ class GinkgoMapsSpider(scrapy.Spider, LomBase):
         yield from self.crawl_next_url_level(diff_set, response, url_depth)
 
     def get_navigation_urls_third_level(self, response: scrapy.http.Response):
+        """
+
+        @url http://ginkgomaps.com/landkarten_midway_midwayinseln.html
+        @returns requests 10
+        """
         url_depth = 3
         yield from self.check_for_dead_ends_before_parsing(response)
         temp_set = set()
@@ -169,6 +185,12 @@ class GinkgoMapsSpider(scrapy.Spider, LomBase):
         #       len(self.navigation_urls))
 
     def parse(self, response: scrapy.http.Response, **kwargs):
+        """
+
+        Scrapy Contracts:
+        @url http://ginkgomaps.com/landkarten_deutschland.html
+        @returns items 1
+        """
         # making sure that the current url is marked as parsed:
         self.debug_parsed_urls.add(response.url)
 

--- a/converter/spiders/kmap_spider.py
+++ b/converter/spiders/kmap_spider.py
@@ -16,7 +16,7 @@ from converter.web_tools import WebEngine, WebTools
 class KMapSpider(CrawlSpider, LomBase):
     name = "kmap_spider"
     friendlyName = "KMap.eu"
-    version = "0.0.5"
+    version = "0.0.5"   # last update: 2021-10-04
     sitemap_urls = [
         "https://kmap.eu/server/sitemap/Mathematik",
         "https://kmap.eu/server/sitemap/Physik"
@@ -31,6 +31,12 @@ class KMapSpider(CrawlSpider, LomBase):
             yield scrapy.Request(url=sitemap_url, callback=self.parse_sitemap)
 
     def parse_sitemap(self, response) -> scrapy.Request:
+        """
+
+        Scrapy Contracts:
+        @url https://kmap.eu/server/sitemap/Mathematik
+        @returns requests 50
+        """
         sitemap_items = from_xml_response(response)
         for sitemap_item in sitemap_items:
             temp_dict = {
@@ -45,6 +51,12 @@ class KMapSpider(CrawlSpider, LomBase):
         pass
 
     def parse(self, response: scrapy.http.Response, **kwargs) -> BaseItemLoader:
+        """
+
+        Scrapy Contracts:
+        @url https://kmap.eu/app/browser/Mathematik/Exponentialfunktionen/Asymptoten
+        @returns item 1
+        """
         last_modified = kwargs.get("lastModified")
         url_data_splash_dict = WebTools.getUrlData(response.url, engine=WebEngine.Pyppeteer)
         splash_html_string = url_data_splash_dict.get('html')

--- a/converter/spiders/materialnetzwerk_spider.py
+++ b/converter/spiders/materialnetzwerk_spider.py
@@ -14,7 +14,7 @@ from converter.valuespace_helper import ValuespaceHelper
 class MaterialNetzwerkSpider(CrawlSpider, LomBase):
     name = "materialnetzwerk_spider"
     friendlyName = "Materialnetzwerk.org"
-    version = "0.0.4"  # last update: 2021-09-17
+    version = "0.0.5"  # last update: 2021-09-29
     start_urls = [
         # 'https://editor.mnweg.org/?p=1&materialType=bundle',
         # this doesn't list any materials since they're loaded dynamically
@@ -54,7 +54,7 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
 
         Spider Contracts:
         @url https://editor.mnweg.org/api/v1/share/bundle?groupSlug=mnw&page=0&pageSize=10000&q
-        @returns requests 43
+        @returns requests 48
 
         :param response: scrapy.http.Response
         :return: scrapy.Request
@@ -219,9 +219,19 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
         lom.add_value('technical', technical.load_item())
 
         lifecycle = LomLifecycleItemloader()
-        bundle_organization = kwargs.get('bundle_ld_json_organization')
+        bundle_organization: dict = kwargs.get('bundle_ld_json_organization')
+        # the dictionary that we can parse from the website itself looks like this:
+        # 'organization': {'@context': 'http://schema.org',
+        #                   '@type': 'Organization',
+        #                   'name': 'Materialnetzwerk e. G.',
+        #                   'sameAs': ['http://twitter.com/materialnw',
+        #                              'https://www.facebook.com/materialnetzwerk'],
+        #                   'url': 'https://editor.mnweg.org'}}
+        # TODO: once its possible to parse a 'organization'-schema-type as a dictionary by the back-end, use
+        #   lifecycle.add_value('organization', bundle_organization)
         if bundle_organization is not None:
-            lifecycle.add_value('organization', bundle_organization)
+            lifecycle.add_value('organization', bundle_organization.get("name"))
+            lifecycle.add_value('url', bundle_organization.get("url"))
         lifecycle.add_value('date', date_published)
         lom.add_value('lifecycle', lifecycle.load_item())
 

--- a/converter/spiders/materialnetzwerk_spider.py
+++ b/converter/spiders/materialnetzwerk_spider.py
@@ -14,7 +14,7 @@ from converter.valuespace_helper import ValuespaceHelper
 class MaterialNetzwerkSpider(CrawlSpider, LomBase):
     name = "materialnetzwerk_spider"
     friendlyName = "Materialnetzwerk.org"
-    version = "0.0.3"
+    version = "0.0.4"  # last update: 2021-09-17
     start_urls = [
         # 'https://editor.mnweg.org/?p=1&materialType=bundle',
         # this doesn't list any materials since they're loaded dynamically
@@ -31,6 +31,7 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
     discipline_mapping = {
         'AES': "Ernährung und Hauswirtschaft",  # Ernährung und Hauswirtschaft
     }
+
     # debug_disciplines = set()
 
     def __init__(self, **kwargs):
@@ -47,8 +48,19 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
             yield scrapy.Request(url=start_url, callback=self.parse_start_url)
 
     def parse_start_url(self, response: scrapy.http.Response, **kwargs):
+        """
+        Parses the API for all available bundles and yields exactly one scrapy.Request per bundle-overview-page for
+        further metadata extraction (with a callback to the parse_bundle_overview()-method).
+
+        Spider Contracts:
+        @url https://editor.mnweg.org/api/v1/share/bundle?groupSlug=mnw&page=0&pageSize=10000&q
+        @returns requests 43
+
+        :param response: scrapy.http.Response
+        :return: scrapy.Request
+        """
         api_response = json.loads(response.body)
-        amount_of_bundles = api_response["total"]
+        # amount_of_bundles = api_response["total"]
         # print("Total amount of material bundles to crawl:", amount_of_bundles, type(amount_of_bundles))
         # the API returns a list of bundles and within each bundle object is a "slug"-key, whose value is part of the
         # unique URL that we need to parse later
@@ -63,6 +75,16 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
         # print(bundle_urls)
 
     def parse_bundle_overview(self, response: scrapy.http.Response):
+        """
+
+        Spider Contracts:
+        @url https://editor.mnweg.org/mnw/sammlung/das-menschliche-skelett-m-78
+        @returns requests 1
+
+        :param response: scrapy.http.Response
+        :return: yields a scrapy.Request for the first worksheet
+        """
+
         # a typical bundle_overview looks like this: https://editor.mnweg.org/mnw/sammlung/das-menschliche-skelett-m-78
         # there's minimal metadata to be found, but we can grab the descriptions of each worksheet and use the
         # accumulated strings as our description for the bundle page
@@ -147,11 +169,20 @@ class MaterialNetzwerkSpider(CrawlSpider, LomBase):
         pass
 
     def parse(self, response: scrapy.http.Response, **kwargs):
+        """
+        Parses an individual 'worksheet' and combines the metadata with data from its 'bundle'-dictionary.
+
+        Spider Contracts:
+        @url https://editor.mnweg.org/mnw/dokument/vocabulary-around-the-world-3
+        @returns items 1
+
+        :return: yields a BaseItemLoader
+        """
         # since we're only parsing the first worksheet for some additional metadata, the metadata object will be
         # centered around a bundle, not the individual pages
 
         # print("DEBUG parse_worksheet_page", response.url)
-        date_published = response.xpath('//div[@class="meta"]/ul/li[3]/text()').get()
+        date_published = response.xpath('//ul[@class="meta"]/li[3]/text()').get()
 
         base = BaseItemLoader()
         base.add_value("sourceId", kwargs.get('bundle_url'))

--- a/converter/spiders/zum_mathe_apps_spider.py
+++ b/converter/spiders/zum_mathe_apps_spider.py
@@ -21,7 +21,7 @@ class ZumMatheAppsSpider(scrapy.Spider, LomBase):
         "https://www.walter-fendt.de/html5/mde/",
         # "http://www.zum.de/ma/fendt/mde/"
     ]
-    version = "0.0.5"  # reflects the structure of ZUM Mathe Apps on 2021-07-19
+    version = "0.0.5"  # reflects the structure of ZUM Mathe Apps on 2021-09-30
     # keep the console clean from spammy DEBUG-level logging messages, adjust as needed:
     logging.getLogger('websockets.server').setLevel(logging.ERROR)
     logging.getLogger('websockets.protocol').setLevel(logging.ERROR)
@@ -36,7 +36,15 @@ class ZumMatheAppsSpider(scrapy.Spider, LomBase):
         for url in self.start_urls:
             yield scrapy.Request(url=url, callback=self.parse_topic_overview)
 
-    def parse_topic_overview(self, response: scrapy.http.Response):
+    def parse_topic_overview(self, response: scrapy.http.Response) -> scrapy.Request:
+        """
+        Parses a topic overview for individual topics and yields the residing URLs to specialised subtopic-methods() or
+        the main parse()-method.
+
+        Scrapy Contracts:
+        @url https://www.walter-fendt.de/html5/mde/
+        @returns requests 42
+        """
         # the different topics are within tables: response.xpath('//table[@class="Gebiet"]')
         topic_urls = response.xpath('//td[@class="App"]/a/@href').getall()
         for topic_url in topic_urls:
@@ -64,6 +72,13 @@ class ZumMatheAppsSpider(scrapy.Spider, LomBase):
             yield scrapy.Request(url=apollo_url, callback=self.parse)
 
     def parse(self, response: scrapy.http.Response, **kwargs):
+        """
+        Populates a BaseItemLoader with metadata and yields the BaseItem afterwards.
+
+        Scrapy Contracts:
+        @url https://www.walter-fendt.de/html5/mde/pythagoras2_de.htm
+        @returns items 1
+        """
         # fetching publication date and lastModified from dynamically loaded <p class="Ende">-element:
         url_data_splash_dict = WebTools.getUrlData(response.url, engine=WebEngine.Pyppeteer)
         splash_html_string = url_data_splash_dict.get('html')

--- a/converter/spiders/zum_physik_apps_spider.py
+++ b/converter/spiders/zum_physik_apps_spider.py
@@ -20,7 +20,7 @@ class ZumPhysikAppsSpider(scrapy.Spider, LomBase):
         "https://www.walter-fendt.de/html5/phde/",
         # "https://www.zum.de/ma/fendt/phde/"
     ]
-    version = "0.0.5"  # reflects the structure of ZUM Physik Apps on 2021-07-15 (there should be 55 scraped items
+    version = "0.0.5"  # reflects the structure of ZUM Physik Apps on 2021-09-30 (there should be 55 scraped items
 
     # when the crawling process is done)
 
@@ -35,6 +35,16 @@ class ZumPhysikAppsSpider(scrapy.Spider, LomBase):
             yield scrapy.Request(url=url, callback=self.parse_topic_overview)
 
     def parse_topic_overview(self, response: scrapy.http.Response):
+        """
+        Looks for individual topics within the overview and yields the URL to the main parse()-method.
+
+        :param response: the current 'url' from start_urls
+        :return: scrapy.Request
+
+        Scrapy Contracts:
+        @url https://www.walter-fendt.de/html5/phde/
+        @returns requests 50
+        """
         # the different topics are within tables: response.xpath('//table[@class="Gebiet"]')
         topic_urls = response.xpath('//td[@class="App"]/a/@href').getall()
         for topic_url in topic_urls:
@@ -42,6 +52,14 @@ class ZumPhysikAppsSpider(scrapy.Spider, LomBase):
             yield scrapy.Request(url=topic_url, callback=self.parse)
 
     def parse(self, response: scrapy.http.Response, **kwargs):
+        """
+        Populates a BaseItemLoader with metadata and yields the individual BaseItem via BaseItemLoader.load_item()
+        afterwards.
+
+        Scrapy Contracts:
+        @url https://www.walter-fendt.de/html5/phde/newtonlaw2_de.htm
+        @returns item 1
+        """
         # fetching publication date and lastModified from dynamically loaded <p class="Ende">-element:
         url_data_splash_dict = WebTools.getUrlData(response.url, engine=WebEngine.Pyppeteer)
         splash_html_string = url_data_splash_dict.get('html')


### PR DESCRIPTION
While testing out Scrapy Contracts and 'Spidermon' I've added a few basic Scrapy Contracts to a handful of Crawlers where the Contracts were easier to implement. (Contracts for crawlers that inherit from (multiple) other classes are still WIP)

During those experiments I've also noticed that `materialnetzwerk_spider` was broken (site structure changed in the meantime, new materials were added as well), therefore I fixed it.

Furthermore I've added some explanations in regards to Pyppeteer to the `Readme.md` and the `.env.example`.