### PR TITLE
fix: mediawiki_base technical.location (URL)

### DIFF
--- a/converter/spiders/base_classes/mediawiki_base.py
+++ b/converter/spiders/base_classes/mediawiki_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import urllib.parse
 from pathlib import Path
 from urllib import parse
 
@@ -239,7 +240,7 @@ class MediaWikiBase(LomBase, metaclass=SpiderBase):
         loader.replace_value('format', 'text/html')
         data = response.meta['item']
         title = jmes_title.search(data)
-        loader.replace_value('location', f'{self.url}wiki/{title}')
+        loader.replace_value('location', f'{self.url}wiki/{urllib.parse.quote(title)}')
         return loader
 
     def getValuespaces(self, response):


### PR DESCRIPTION
- fix: URLs to individual items within `ccm:wwwurl` were sometimes malformed due to string-concatenation of the base-URL and the title without proper URL-encoding