### PR TITLE
science_in_school_spider v0.0.2 ("general.language" fix)

### DIFF
--- a/converter/spiders/sample_spider_alternative.py
+++ b/converter/spiders/sample_spider_alternative.py
@@ -82,7 +82,8 @@ class SampleSpiderAlternative(CrawlSpider, LomBase):
         #  - title                          required
         #  - keyword                        required
         #  - description                    required
-        #  - language                       recommended
+        #  - language                       recommended (edu-sharing expects underscores in language-codes, e.g. 'en-US'
+        #                                               needs to be replaced by 'en_US')
         #  - coverage                       optional
         #  - structure                      optional
         #  - aggregationLevel               optional


### PR DESCRIPTION
Since the edu-sharing repo is expecting values for the `general.language`-field to be formatted with underscores, I added a quick fix for that to science_in_school_spider and also documented this circumstance in our `sample_spider_alternative.py`.