### PR TITLE
sodix_spider v0.1.8

### DIFF
--- a/.run/sodix_spider.run.xml
+++ b/.run/sodix_spider.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sodix_spider" type="PythonConfigurationType" factoryName="Python">
+    <output_file path="$PROJECT_DIR$/logs/sodix_spider_console.log" is_save="true" />
+    <module name="oeh-search-etl" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/converter/spiders" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="scrapy.cmdline" />
+    <option name="PARAMETERS" value="crawl sodix_spider -O &quot;../../logs/sodix_spider.json&quot;" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="true" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/converter/spiders/base_classes/lom_base.py
+++ b/converter/spiders/base_classes/lom_base.py
@@ -97,7 +97,7 @@ class LomBase:
         main.add_value("valuespaces", self.getValuespaces(response).load_item())
         main.add_value("license", self.getLicense(response).load_item())
         main.add_value("permissions", self.getPermissions(response).load_item())
-        logging.debug(main.load_item())
+        # logging.debug(main.load_item())
         main.add_value("response", self.mapResponse(response).load_item())
         return main.load_item()
 


### PR DESCRIPTION
Implements fixes and improvements for:
- `technical.duration`
- `technical.location`
- `valuespaces.intendedEndUserRole`
- `valuespaces.discipline`
-- improved how "subjects" from the Sodix API are treated: Since there are ~837 unique values (from Sodix) where >90% can't get mapped to our "discipline"-vocab, these (still useful) values are put into our "keyword"-field. While this adds slight redundancy for some items on our end, it makes sure that we're not losing useful metadata on the majority of Sodix items.

Furthermore: 
- includes the run/debug configuration for pyCharm