### PR TITLE
Splash pipeline fix

### DIFF
--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -324,7 +324,8 @@ class ProcessThumbnailPipeline(BasicPipeline):
                 response = requests.post(
                     settings.get("SPLASH_URL") + "/render.png",
                     json={
-                        "url": item["lom"]["technical"]["location"],
+                        "url": item["lom"]["technical"]["location"][0],
+                        # since there can be multiple "technical.location"-values, the first URL is used for thumbnails
                         "wait": settings.get("SPLASH_WAIT"),
                         "html5_media": 1,
                         "headers": settings.get("SPLASH_HEADERS"),

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -317,6 +317,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
             )
         elif (
                 "location" in item["lom"]["technical"]
+                and len(item["lom"]["technical"]["location"]) > 0
                 and "format" in item["lom"]["technical"]
                 and item["lom"]["technical"]["format"] == "text/html"
         ):

--- a/converter/web_tools.py
+++ b/converter/web_tools.py
@@ -47,10 +47,9 @@ class WebTools:
     def __getUrlDataSplash(url: str):
         settings = get_project_settings()
         # html = None
-        if settings.get("SPLASH_URL") and not url.endswith((".pdf", ".docx")):
+        if settings.get("SPLASH_URL") and not url.endswith(".pdf") and not url.endswith(".docx"):
             # Splash can't handle some binary direct-links (Splash will throw "LUA Error 400: Bad Request" as a result)
-            # ToDo: which additional filetypes need to be added to the exclusion list?
-            # ToDo: find general solution for extracting metadata from .pdf-files?
+            # ToDo: which additional filetypes need to be added to the exclusion list? - media files (.mp3, mp4 etc.?)
             result = requests.post(
                 settings.get("SPLASH_URL") + "/render.json",
                 json={


### PR DESCRIPTION
- fix: Splash pipelines uses the first "technical.location"-URL
- fix: filtering for ".pdf" and ".docx" files