### PR TITLE
Screenshot to Thumbnail Pipeline: Playwright implementation

### DIFF
--- a/converter/items.py
+++ b/converter/items.py
@@ -194,6 +194,8 @@ class BaseItem(Item):
     "editorial notes"
     binary = Field()
     "binary data which should be uploaded (raw data)"
+    screenshot_bytes = Field()
+    # this is a (temporary) field that gets deleted after the thumbnail pipeline processed its byte-data
 
 
 class BaseItemLoader(ItemLoader):

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -326,7 +326,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
         item = ItemAdapter(raw_item)
         response = None
         url = None
-        settings = self.get_settings_for_crawler(spider)
+        settings = get_settings_for_crawler(spider)
         # checking if the (optional) attribute WEB_TOOLS exists:
         web_tools = settings.get("WEB_TOOLS", WebEngine.Splash)
         # if screenshot_bytes is provided (the crawler has already a binary representation of the image
@@ -426,16 +426,6 @@ class ProcessThumbnailPipeline(BasicPipeline):
 
     # override the project settings with the given ones from the current spider
     # see PR 56 for details
-    def get_settings_for_crawler(self, spider):
-        all_settings = get_project_settings()
-        crawler_settings = getattr(spider, "custom_settings", {})
-        for key in crawler_settings.keys():
-            if (
-                    all_settings.get(key) and crawler_settings.get(key).priority > all_settings.get(key).priority
-                    or not all_settings.get(key)
-            ):
-                all_settings.set(key, crawler_settings.get(key))
-        return all_settings
 
     def create_thumbnails_from_image_bytes(self, image, item, settings):
         small = BytesIO()
@@ -460,6 +450,18 @@ class ProcessThumbnailPipeline(BasicPipeline):
         item["thumbnail"]["large"] = base64.b64encode(
             large.getvalue()
         ).decode()
+
+
+def get_settings_for_crawler(spider):
+    all_settings = get_project_settings()
+    crawler_settings = getattr(spider, "custom_settings", {})
+    for key in crawler_settings.keys():
+        if (
+                all_settings.get(key) and crawler_settings.getpriority(key) > all_settings.getpriority(key)
+                or not all_settings.get(key)
+        ):
+            all_settings.set(key, crawler_settings.get(key), crawler_settings.getpriority(key))
+    return all_settings
 
 
 class EduSharingCheckPipeline(EduSharing, BasicPipeline):

--- a/converter/spiders/base_classes/lom_base.py
+++ b/converter/spiders/base_classes/lom_base.py
@@ -1,7 +1,7 @@
 import html2text
 import logging
 
-import scrapy.settings
+from scrapy import settings
 from scrapy.utils.project import get_project_settings
 
 from converter.constants import Constants
@@ -23,10 +23,10 @@ class LomBase:
     forceUpdate = False
 
     # you can specify custom settings which will later influence the behaviour of the pipelines for your crawler
-    custom_settings: scrapy.settings.Settings = {
+    custom_settings = settings.BaseSettings({
         # web tools to use, relevant for screenshots/thumbnails
-        "WEB_TOOLS": scrapy.settings.SettingsAttribute(WebEngine.Splash, scrapy.settings.SETTINGS_PRIORITIES["spider"])
-    }
+        "WEB_TOOLS": WebEngine.Splash,
+    }, 'spider')
 
     def __init__(self, **kwargs):
         if self.name is None:

--- a/converter/spiders/base_classes/lom_base.py
+++ b/converter/spiders/base_classes/lom_base.py
@@ -1,5 +1,7 @@
 import html2text
 import logging
+
+import scrapy.settings
 from scrapy.utils.project import get_project_settings
 
 from converter.constants import Constants
@@ -19,6 +21,12 @@ class LomBase:
     uuid = None
     remoteId = None
     forceUpdate = False
+
+    # you can specify custom settings which will later influence the behaviour of the pipelines for your crawler
+    custom_settings: scrapy.settings.Settings = {
+        # web tools to use, relevant for screenshots/thumbnails
+        "WEB_TOOLS": scrapy.settings.SettingsAttribute(WebEngine.Splash, scrapy.settings.SETTINGS_PRIORITIES["spider"])
+    }
 
     def __init__(self, **kwargs):
         if self.name is None:

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 import scrapy
-import scrapy.settings
+from scrapy import settings
 
 from converter.constants import Constants
 from converter.items import BaseItemLoader, LomBaseItemloader, LomGeneralItemloader, LomTechnicalItemLoader, \
@@ -18,10 +18,10 @@ class SerloSpider(scrapy.Spider, LomBase):
     API_URL = "https://api.serlo.org/graphql"
     # for the API description, please check: https://lenabi.serlo.org/metadata-api
     version = "0.2.2"  # last update: 2022-07-29
-    custom_settings: scrapy.settings.Settings = {
-        # playwright cause of issues with thumbnails+text for serlo
-        "WEB_TOOLS": scrapy.settings.SettingsAttribute(WebEngine.Playwright, scrapy.settings.SETTINGS_PRIORITIES["spider"])
-    }
+    custom_settings = settings.BaseSettings({
+            # playwright cause of issues with thumbnails+text for serlo
+            "WEB_TOOLS": WebEngine.Playwright
+        }, 'spider')
 
     graphql_items = list()
     # Mapping from EducationalAudienceRole (LRMI) to IntendedEndUserRole(LOM), see:

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -2,21 +2,22 @@ import json
 
 import requests
 import scrapy
-from scrapy.spiders import CrawlSpider
 
 from converter.constants import Constants
 from converter.items import BaseItemLoader, LomBaseItemloader, LomGeneralItemloader, LomTechnicalItemLoader, \
     LomLifecycleItemloader, LomEducationalItemLoader, ValuespaceItemLoader, LicenseItemLoader
 from converter.spiders.base_classes import LomBase
+from converter.web_tools import WebEngine
 
 
-class SerloSpider(CrawlSpider, LomBase):
+class SerloSpider(scrapy.Spider, LomBase):
     name = "serlo_spider"
     friendlyName = "serlo_spider"
     # start_urls = ["https://de.serlo.org"]
     API_URL = "https://api.serlo.org/graphql"
     # for the API description, please check: https://lenabi.serlo.org/metadata-api
-    version = "0.2"  # last update: 2022-03-14
+    version = "0.2.1"  # last update: 2022-07-29
+    WEB_TOOLS = WebEngine.Playwright
 
     graphql_items = list()
     # Mapping from EducationalAudienceRole (LRMI) to IntendedEndUserRole(LOM), see:

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 import scrapy
+import scrapy.settings
 
 from converter.constants import Constants
 from converter.items import BaseItemLoader, LomBaseItemloader, LomGeneralItemloader, LomTechnicalItemLoader, \
@@ -17,7 +18,10 @@ class SerloSpider(scrapy.Spider, LomBase):
     API_URL = "https://api.serlo.org/graphql"
     # for the API description, please check: https://lenabi.serlo.org/metadata-api
     version = "0.2.2"  # last update: 2022-07-29
-    WEB_TOOLS = WebEngine.Playwright
+    custom_settings: scrapy.settings.Settings = {
+        # playwright cause of issues with thumbnails+text for serlo
+        "WEB_TOOLS": scrapy.settings.SettingsAttribute(WebEngine.Playwright, scrapy.settings.SETTINGS_PRIORITIES["spider"])
+    }
 
     graphql_items = list()
     # Mapping from EducationalAudienceRole (LRMI) to IntendedEndUserRole(LOM), see:

--- a/converter/web_tools.py
+++ b/converter/web_tools.py
@@ -40,8 +40,14 @@ class WebTools:
 
     @staticmethod
     def __getUrlDataPlaywright(url: str):
-        html = asyncio.run(WebTools.fetchDataPlaywright(url))
-        return {"html": html, "text": WebTools.html2Text(html), "cookies": None, "har": None}
+        playwright_dict = asyncio.run(WebTools.fetchDataPlaywright(url))
+        html = playwright_dict.get("content")
+        screenshot_bytes = playwright_dict.get("screenshot_bytes")
+        return {"html": html,
+                "text": WebTools.html2Text(html),
+                "cookies": None,
+                "har": None,
+                "screenshot_bytes": screenshot_bytes}
 
     @staticmethod
     def __getUrlDataSplash(url: str):
@@ -99,8 +105,15 @@ class WebTools:
             # waits for page to fully load (= no network traffic for 500ms),
             # maximum timeout: 90s
             content = await page.content()
+            screenshot_bytes = await page.screenshot()
+            # ToDo: HAR / text / cookies
+            #  if we are able to replicate the Splash response with all its fields, we could save traffic/Requests
+            #  that are currently still being handled by Splash
             # await page.close()
-            return content
+            return {
+                "content": content,
+                "screenshot_bytes": screenshot_bytes
+            }
 
     @staticmethod
     def html2Text(html: str):


### PR DESCRIPTION
Implemented a (hacky) solution to (optionally) fetch Screenshots via Playwright if Splash isn't handling a website well.
- by default, Splash is always used (as previously) for website screenshots
- the (optional) class-attribute `WEB_TOOLS` can be used to control which Screenshot-Pipeline should be used
   - this approach was used, so we don't have to change previous crawler implementations – if the field is available, it will be used, otherwise it just defaults back to "Splash"
   - if we are already using Playwright for metadata extraction within a spider, we can skip one (unnecessary) call to the target-website by saving the screenshot's image-bytes to the (temporary) `screenshot_bytes`-field of our `BaseItemLoader`
   - the `screenshot_bytes`-field gets automatically deleted once the "Screenshot->Thumbnail"-Pipeline is done with the image rescaling and saving
- bumped serlo_spider to v0.2.2 to use Playwright's html_body, fulltext and screenshot results instead of depending on Splash

---
## observations while tinkering/debugging
This solution is a compromise after discovering weird behaviour with `custom_settings` (see: [per-spider Settings](https://docs.scrapy.org/en/latest/topics/settings.html#settings-per-spider)):
- the `get_project_settings()`-method seems to ignore spider-specific settings that have been provided within the `custom_settings`-class attribute
- (for [context](https://docs.scrapy.org/en/latest/topics/settings.html#populating-the-settings): the [Scrapy Settings Priorities](https://docs.scrapy.org/en/latest/topics/api.html#scrapy.settings.SETTINGS_PRIORITIES))
	- *project-wide* settings from the `settings.py` have a `priority`-value of 20
	- **spider-specific** settings from `custom_settings = {}` **should have** a `priority` of **30**, which means they have priority over `settings.py`
		- but these settings don't show up at all when calling `get_project_settings()` in the pipeline

---
The preferred (clean) solution would've been to implement and control the `WEB_TOOLS`-setting via Scrapy's (spider-specific) Settings:
```python
custom_settings = {
   "WEB_TOOLS": WebEngine.Playwright
}
```
Evaluating the pipeline process at runtime with `settings.copy_to_dict()` or `settings.maxpriority()` confirmed the above mentioned suspicion.

If we add `WEB_TOOLS = WebEngine.Splash` to our `settings.py`, the priority at runtime for the `WEB_TOOLS`-setting will stay at 20, even though the expected behavior of overwriting this setting within `custom_settings` would be: The `WEB_TOOLS`-value `WebEngine.Playwright` showing up with a priority of 30.