### PR TITLE
Lehrer-Online (v0.0.5) Themenportale + fix 'sourceContentType'

### DIFF
--- a/converter/items.py
+++ b/converter/items.py
@@ -130,6 +130,8 @@ class ValuespaceItem(Item):
     learningResourceType = Field(output_processor=JoinMultivalues())
     new_lrt = Field(output_processor=JoinMultivalues())
     sourceContentType = Field(output_processor=JoinMultivalues())
+    # ToDo: sourceContentType is no longer used in edu-sharing
+    # DO NOT SET this field in crawlers for individual materials!
     toolCategory = Field(output_processor=JoinMultivalues())
 
     conditionsOfAccess = Field(output_processor=JoinMultivalues())

--- a/converter/spiders/grundschulkoenig_spider.py
+++ b/converter/spiders/grundschulkoenig_spider.py
@@ -19,7 +19,7 @@ class GrundSchulKoenigSpider(CrawlSpider, LomBase):
 
     start_urls = ['https://www.grundschulkoenig.de/sitemap.xml?sitemap=pages&cHash=b8e1a6633393d69093d0ebe93a3d2616']
     name = 'grundschulkoenig_spider'
-    version = "0.0.6"  # last update: 2022-08-03
+    version = "0.0.7"  # last update: 2022-08-26
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
         # while there is no robots.txt, there is a 404-forward-page that gets misinterpreted by Scrapy
@@ -178,7 +178,6 @@ class GrundSchulKoenigSpider(CrawlSpider, LomBase):
             vs.add_value('discipline', "Religionsunterricht")
         vs.add_value('discipline', 'Allgemein')
         vs.add_value('educationalContext', 'Primarstufe')
-        vs.add_value('sourceContentType', "Unterrichtsmaterial- und Aufgaben-Sammlung")
         # vs.add_value('learningResourceType', 'other_asset_type')
         # ToDo: new_lrt
         if "/vorschule/" in response.url:

--- a/converter/spiders/sample_spider_alternative.py
+++ b/converter/spiders/sample_spider_alternative.py
@@ -176,8 +176,6 @@ class SampleSpiderAlternative(CrawlSpider, LomBase):
         #  (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/price.ttl)
         #  - educationalContext             optional
         #  (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/educationalContext.ttl)
-        #  - sourceContentType              optional
-        #  (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/sourceContentType.ttl)
         #  - toolCategory                   optional
         #  (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/toolCategory.ttl)
         #  - accessibilitySummary           optional

--- a/converter/spiders/science_in_school_spider.py
+++ b/converter/spiders/science_in_school_spider.py
@@ -17,7 +17,7 @@ class ScienceInSchoolSpider(scrapy.Spider, LomBase):
     start_urls = [
         "https://www.scienceinschool.org/issue/"
     ]
-    version = "0.0.3"  # last update: 2022-07-11
+    version = "0.0.4"  # last update: 2022-08-26
     custom_settings = {
         "AUTOTHROTTLE_ENABLED": True,
         "AUTOTHROTTLE_DEBUG": True
@@ -311,7 +311,6 @@ class ScienceInSchoolSpider(scrapy.Spider, LomBase):
         vs = ValuespaceItemLoader()
         vs.add_value('discipline', disciplines)
         vs.add_value('intendedEndUserRole', 'teacher')
-        vs.add_value('sourceContentType', 'Lehrkräftefortbildung')
         vs.add_value('dataProtectionConformity', 'generalDataProtectionRegulation')
         # see: https://www.embl.de/aboutus/privacy_policy/
         vs.add_value('new_lrt', [Constants.NEW_LRT_MATERIAL,

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -17,7 +17,7 @@ class SerloSpider(scrapy.Spider, LomBase):
     # start_urls = ["https://de.serlo.org"]
     API_URL = "https://api.serlo.org/graphql"
     # for the API description, please check: https://lenabi.serlo.org/metadata-api
-    version = "0.2.2"  # last update: 2022-07-29
+    version = "0.2.3"  # last update: 2022-08-26
     custom_settings = settings.BaseSettings({
             # playwright cause of issues with thumbnails+text for serlo
             "WEB_TOOLS": WebEngine.Playwright
@@ -316,8 +316,6 @@ class SerloSpider(scrapy.Spider, LomBase):
         if graphql_json["learningResourceType"] is not None:
             # (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/learningResourceType.ttl)
             vs.add_value('learningResourceType', graphql_json["learningResourceType"])
-        vs.add_value('sourceContentType', "Lernportal")
-        # (see: https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/sourceContentType.ttl)
 
         base.add_value('valuespaces', vs.load_item())
 


### PR DESCRIPTION
Crawler-Update for Lehrer-Online that implements different 'origin'-folders depending on which "Themenportal" a material is crawled from. Materials belonging to specific sub-sections of Lehrer-Online will be crawled into `Themenportal_Handwerk_-_` or `Themenportal_Pubertaet_-_`-folders in edu-sharing.

Furthermore discovered that some crawlers (accidentally) set `valuespaces.sourceContentType` for materials. This was never intentional (since `sourceContentType` is a field only intended to be set for "Quellen", not individually crawled materials) and has now been removed from the affected spiders and from the `sample_spider_alternative`-blueprint.