### PR TITLE
sodix_spider v0.1.9 (WIP?)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-CRAWLER=wirlernenonline_spider
-LOG_LEVEL=INFO
-EDU_SHARING_BASE_URL=http://host.docker.internal/edu-sharing/
-EDU_SHARING_USERNAME=admin
-EDU_SHARING_PASSWORD=Joint#17#

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.10.0-slim-buster
 
-ENV CRAWLER wirlernenonline_spider 
+# ENV CRAWLER wirlernenonline_spider
 
 WORKDIR /
 
+COPY entrypoint.sh entrypoint.sh
 COPY requirements.txt requirements.txt
 COPY scrapy.cfg scrapy.cfg
 COPY setup.cfg setup.cfg
@@ -14,4 +15,4 @@ COPY valuespace_converter/ valuespace_converter/
 RUN pip3 install -r requirements.txt
 
 
-CMD scrapy crawl "$CRAWLER"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/converter/.env.example
+++ b/converter/.env.example
@@ -26,6 +26,9 @@ EDU_SHARING_BASE_URL = "http://localhost:8080/edu-sharing/"
 EDU_SHARING_USERNAME = "admin"
 EDU_SHARING_PASSWORD = "admin"
 
+# Configure if permissions of edu-sharing nodes are handled by the crawler (default true)
+# You may want to set this to false if you don't want to apply permissions from crawlers or have a custom implementation in the repository
+# EDU_SHARING_PERMISSION_CONTROL=true
 # Metadataset to be used for generated nodes. You may use "default" to use the default mds of the repository
 # EDU_SHARING_METADATASET=mds_oeh
 

--- a/converter/.env.example
+++ b/converter/.env.example
@@ -32,6 +32,11 @@ EDU_SHARING_PASSWORD = "admin"
 # If set to true, don't upload to (above mentioned) Edu-Sharing instance
 DRY_RUN = True
 
+# you can add one or more custom pipelines here to trigger
+# the syntax is: pipeline.package.id:PRIORITY[,pipeline.package.id:PRIORITY,...]
+# Use this if you e.g. want to do custom property mapping for any crawler before storing the data
+# CUSTOM_PIPELINES = "converter.pipelines.ExampleLoggingPipeline:100"
+
 # your youtube api key (required for youtube crawler)
 YOUTUBE_API_KEY = ""
 

--- a/converter/.env.example
+++ b/converter/.env.example
@@ -26,6 +26,9 @@ EDU_SHARING_BASE_URL = "http://localhost:8080/edu-sharing/"
 EDU_SHARING_USERNAME = "admin"
 EDU_SHARING_PASSWORD = "admin"
 
+# Metadataset to be used for generated nodes. You may use "default" to use the default mds of the repository
+# EDU_SHARING_METADATASET=mds_oeh
+
 # If set to true, don't upload to (above mentioned) Edu-Sharing instance
 DRY_RUN = True
 

--- a/converter/constants.py
+++ b/converter/constants.py
@@ -2,50 +2,78 @@ from typing import Final, Any
 
 
 class Constants:
+    LICENSE_CC_BY_20: Final[str] = "https://creativecommons.org/licenses/by/2.0/"
+    LICENSE_CC_BY_25: Final[str] = "https://creativecommons.org/licenses/by/2.5/"
     LICENSE_CC_BY_30: Final[str] = "https://creativecommons.org/licenses/by/3.0/"
     LICENSE_CC_BY_40: Final[str] = "https://creativecommons.org/licenses/by/4.0/"
     LICENSE_CC_BY_NC_30: Final[str] = "https://creativecommons.org/licenses/by-nc/3.0/"
     LICENSE_CC_BY_NC_40: Final[str] = "https://creativecommons.org/licenses/by-nc/4.0/"
+    LICENSE_CC_BY_NC_ND_20: Final[str] = "https://creativecommons.org/licenses/by-nc-nd/2.0/"
     LICENSE_CC_BY_NC_ND_30: Final[str] = "https://creativecommons.org/licenses/by-nc-nd/3.0/"
     LICENSE_CC_BY_NC_ND_40: Final[str] = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+    LICENSE_CC_BY_NC_SA_20: Final[str] = "https://creativecommons.org/licenses/by-nc-sa/2.0/"
+    LICENSE_CC_BY_NC_SA_25: Final[str] = "https://creativecommons.org/licenses/by-nc-sa/2.5/"
     LICENSE_CC_BY_NC_SA_30: Final[str] = "https://creativecommons.org/licenses/by-nc-sa/3.0/"
     LICENSE_CC_BY_NC_SA_40: Final[str] = "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+    LICENSE_CC_BY_ND_20: Final[str] = "https://creativecommons.org/licenses/by-nd/2.0/"
     LICENSE_CC_BY_ND_30: Final[str] = "https://creativecommons.org/licenses/by-nd/3.0/"
     LICENSE_CC_BY_ND_40: Final[str] = "https://creativecommons.org/licenses/by-nd/4.0/"
+    LICENSE_CC_BY_SA_20: Final[str] = "https://creativecommons.org/licenses/by-sa/2.0/"
+    LICENSE_CC_BY_SA_25: Final[str] = "https://creativecommons.org/licenses/by-sa/2.5/"
     LICENSE_CC_BY_SA_30: Final[str] = "https://creativecommons.org/licenses/by-sa/3.0/"
     LICENSE_CC_BY_SA_40: Final[str] = "https://creativecommons.org/licenses/by-sa/4.0/"
     LICENSE_CC_ZERO_10: Final[str] = "https://creativecommons.org/publicdomain/zero/1.0/"
     LICENSE_PDM: Final[str] = "https://creativecommons.org/publicdomain/mark/1.0/"
 
     VALID_LICENSE_URLS: list[str | Any] = [
+        LICENSE_CC_BY_20,
+        LICENSE_CC_BY_25,
         LICENSE_CC_BY_30,
         LICENSE_CC_BY_40,
         LICENSE_CC_BY_NC_30,
         LICENSE_CC_BY_NC_40,
+        LICENSE_CC_BY_NC_ND_20,
         LICENSE_CC_BY_NC_ND_30,
         LICENSE_CC_BY_NC_ND_40,
+        LICENSE_CC_BY_NC_SA_20,
+        LICENSE_CC_BY_NC_SA_25,
         LICENSE_CC_BY_NC_SA_30,
         LICENSE_CC_BY_NC_SA_40,
+        LICENSE_CC_BY_ND_20,
         LICENSE_CC_BY_ND_30,
         LICENSE_CC_BY_ND_40,
+        LICENSE_CC_BY_SA_20,
+        LICENSE_CC_BY_SA_25,
         LICENSE_CC_BY_SA_30,
         LICENSE_CC_BY_SA_40,
         LICENSE_CC_ZERO_10,
         LICENSE_PDM,
     ]
     LICENSE_MAPPINGS: dict[str, str] = {
-        "https://creativecommons.org/licenses/by/": LICENSE_CC_BY_40,  # ToDo: outdated approximation?
-        # ToDo: - CC_BY_NC (3.0 + 4.0)
+        "https://creativecommons.org/licenses/by/2.0/": LICENSE_CC_BY_20,
+        "https://creativecommons.org/licenses/by/2.5/": LICENSE_CC_BY_25,
+        "https://creativecommons.org/licenses/by/3.0/": LICENSE_CC_BY_30,
+        "https://creativecommons.org/licenses/by/4.0/": LICENSE_CC_BY_40,
+        "https://creativecommons.org/licenses/by-nc/3.0/": LICENSE_CC_BY_NC_30,
+        "https://creativecommons.org/licenses/by-nc/4.0/": LICENSE_CC_BY_NC_40,
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/": LICENSE_CC_BY_NC_ND_20,
         "https://creativecommons.org/licenses/by-nc-nd/3.0/": LICENSE_CC_BY_NC_ND_30,
         "https://creativecommons.org/licenses/by-nc-nd/4.0/": LICENSE_CC_BY_NC_ND_40,
-        # ToDo:
-        #  - CC_BY_NC_SA (3.0 + 4.0)
-        #  - CC_BY_ND (3.0 + 4.0)
-        #  - CC_BY_SA (3.0)
-        "https://creativecommons.org/licenses/by-sa/": LICENSE_CC_BY_SA_40,  # Todo: outdated approximation?
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/": LICENSE_CC_BY_NC_SA_20,
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/": LICENSE_CC_BY_NC_SA_25,
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/": LICENSE_CC_BY_NC_SA_30,
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/": LICENSE_CC_BY_NC_SA_40,
+        "https://creativecommons.org/licenses/by-nd/2.0/": LICENSE_CC_BY_ND_20,
+        "https://creativecommons.org/licenses/by-nd/3.0/": LICENSE_CC_BY_ND_30,
+        "https://creativecommons.org/licenses/by-nd/4.0/": LICENSE_CC_BY_ND_40,
+        "https://creativecommons.org/licenses/by-sa/2.0/": LICENSE_CC_BY_SA_20,
+        "https://creativecommons.org/licenses/by-sa/2.5/": LICENSE_CC_BY_SA_25,
+        "https://creativecommons.org/licenses/by-sa/3.0/": LICENSE_CC_BY_SA_30,
+        "https://creativecommons.org/licenses/by-sa/4.0/": LICENSE_CC_BY_SA_40,
         # wrong mapping (currently from edu-sharing)
         "https://creativecommons.org/publicdomain/zero/": LICENSE_CC_ZERO_10,
         "https://creativecommons.org/licenses/pdm/": LICENSE_PDM,
+        "https://creativecommons.org/publicdomain/mark/1.0/": LICENSE_PDM,
     }
     LICENSE_MAPPINGS_INTERNAL: dict[str, list[str]] = {
         "CC_0": [LICENSE_CC_ZERO_10],

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -633,7 +633,7 @@ class EduSharing:
                     )
                 else:
                     logging.info("Detected edu-sharing bulk api with version " + version_str)
-                if env.get_bool("EDU_SHARING_PERMISSION_CONTROL", False, True) == False:
+                if env.get_bool("EDU_SHARING_PERMISSION_CONTROL", False, True) == True:
                     EduSharing.groupCache = list(
                         map(
                             lambda x: x["authorityName"],

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -15,6 +15,7 @@ from vobject.vcard import VCardBehavior
 
 from converter import env
 from converter.constants import Constants
+from edu_sharing_client import ABOUTApi
 from edu_sharing_client.api.bulk_v1_api import BULKV1Api
 from edu_sharing_client.api.iam_v1_api import IAMV1Api
 from edu_sharing_client.api.mediacenter_v1_api import MEDIACENTERV1Api
@@ -95,7 +96,9 @@ class EduSharing:
 
     cookie: str = None
     resetVersion: bool = False
+    version: any
     apiClient: ESApiClient
+    aboutApi: ABOUTApi
     bulkApi: BULKV1Api
     iamApi: IAMV1Api
     mediacenterApi: MEDIACENTERV1Api
@@ -610,10 +613,20 @@ class EduSharing:
                     header_name="Accept",
                     header_value="application/json",
                 )
+                EduSharing.aboutApi = ABOUTApi(EduSharing.apiClient)
                 EduSharing.bulkApi = BULKV1Api(EduSharing.apiClient)
                 EduSharing.iamApi = IAMV1Api(EduSharing.apiClient)
                 EduSharing.mediacenterApi = MEDIACENTERV1Api(EduSharing.apiClient)
                 EduSharing.nodeApi = NODEV1Api(EduSharing.apiClient)
+                about = EduSharing.aboutApi.about()
+                EduSharing.version = list(filter(lambda x: x["name"] == "BULK", about["services"]))[0]["instances"][0]["version"]
+                version_str = str(EduSharing.version["major"]) + "." + str(EduSharing.version["minor"])
+                if EduSharing.version["major"] != 1 or EduSharing.version["minor"] < 0 or EduSharing.version["minor"] > 1:
+                    raise Exception(
+                        f"Given repository api version is unsupported: " + version_str
+                    )
+                else:
+                    logging.info("Detected edu-sharing bulk api with version " + version_str)
                 EduSharing.groupCache = list(
                     map(
                         lambda x: x["authorityName"],

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -633,16 +633,17 @@ class EduSharing:
                     )
                 else:
                     logging.info("Detected edu-sharing bulk api with version " + version_str)
-                EduSharing.groupCache = list(
-                    map(
-                        lambda x: x["authorityName"],
-                        EduSharing.iamApi.search_groups(
-                            EduSharingConstants.HOME, "", max_items=1000000
-                        )["groups"],
+                if env.get_bool("EDU_SHARING_PERMISSION_CONTROL", False, True) == False:
+                    EduSharing.groupCache = list(
+                        map(
+                            lambda x: x["authorityName"],
+                            EduSharing.iamApi.search_groups(
+                                EduSharingConstants.HOME, "", max_items=1000000
+                            )["groups"],
+                        )
                     )
-                )
-                logging.debug("Built up edu-sharing group cache: {}".format(EduSharing.groupCache))
-                return
+                    logging.debug("Built up edu-sharing group cache: {}".format(EduSharing.groupCache))
+                    return
             logging.warning(auth.text)
             raise Exception(
                 "Could not authentify as admin at edu-sharing. Please check your settings for repository "

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -644,6 +644,8 @@ class EduSharing:
                     )
                     logging.debug("Built up edu-sharing group cache: {}".format(EduSharing.groupCache))
                     return
+                else:
+                    return
             logging.warning(auth.text)
             raise Exception(
                 "Could not authentify as admin at edu-sharing. Please check your settings for repository "

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -293,6 +293,7 @@ class EduSharing:
             "cclom:location": item["lom"]["technical"]["location"]
             if "location" in item["lom"]["technical"] else None,
             "cclom:format": item["lom"]["technical"]["format"] if "format" in item["lom"]["technical"] else None,
+            "cclom:aggregationlevel": item["lom"]["general"]["aggregationLevel"] if "aggregationLevel" in item["lom"]["general"] else None,
             "cclom:title": item["lom"]["general"]["title"],
         }
         if "notes" in item:

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -296,6 +296,7 @@ class EduSharing:
             "cclom:format": item["lom"]["technical"]["format"] if "format" in item["lom"]["technical"] else None,
             "cclom:aggregationlevel": item["lom"]["general"]["aggregationLevel"] if "aggregationLevel" in item["lom"]["general"] else None,
             "cclom:title": item["lom"]["general"]["title"],
+            "cclom:general_identifier": item["lom"]["general"]["identifier"]
         }
         if "notes" in item:
             spaces["ccm:notes"] = item["notes"]
@@ -308,6 +309,9 @@ class EduSharing:
         if "description" in item["lom"]["general"]:
             spaces["cclom:general_description"] = item["lom"]["general"]["description"]
 
+        if "identifier" in item["lom"]["general"]:
+            spaces["cclom:general_identifier"] = item["lom"]["general"]["identifier"]
+
         if "language" in item["lom"]["general"]:
             spaces["cclom:general_language"] = item["lom"]["general"]["language"]
 
@@ -319,7 +323,7 @@ class EduSharing:
             if "duration" in item["lom"]["technical"]:
                 duration = item["lom"]["technical"]["duration"]
                 try:
-                    # edusharing requries milliseconds
+                    # edusharing requires milliseconds
                     duration = int(float(duration) * 1000)
                 except:
                     pass

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -402,8 +402,10 @@ class EduSharing:
         # educationalContext = Field(output_processor=JoinMultivalues())
         # learningResourceType = Field(output_processor=JoinMultivalues())
         # sourceContentType = Field(output_processor=JoinMultivalues())
-        spaces["cm:edu_metadataset"] = "mds_oeh"
-        spaces["cm:edu_forcemetadataset"] = "true"
+        mdsId = env.get("EDU_SHARING_METADATASET", allow_null=True, default="mds_oeh")
+        if mdsId != "default":
+            spaces["cm:edu_metadataset"] = mdsId
+            spaces["cm:edu_forcemetadataset"] = "true"
         for key in spaces:
             if type(spaces[key]) is tuple:
                 spaces[key] = list([x for y in spaces[key] for x in y])

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -221,6 +221,13 @@ class EduSharing:
     def mapLicense(self, spaces, license):
         if "url" in license:
             match license["url"]:
+                # ToDo: refactor this ungodly method asap
+                case Constants.LICENSE_CC_BY_20:
+                    spaces["ccm:commonlicense_key"] = "CC_BY"
+                    spaces["ccm:commonlicense_cc_version"] = "2.0"
+                case Constants.LICENSE_CC_BY_25:
+                    spaces["ccm:commonlicense_key"] = "CC_BY"
+                    spaces["ccm:commonlicense_cc_version"] = "2.5"
                 case Constants.LICENSE_CC_BY_30:
                     spaces["ccm:commonlicense_key"] = "CC_BY"
                     spaces["ccm:commonlicense_cc_version"] = "3.0"
@@ -233,24 +240,42 @@ class EduSharing:
                 case Constants.LICENSE_CC_BY_NC_40:
                     spaces["ccm:commonlicense_key"] = "CC_BY_NC"
                     spaces["ccm:commonlicense_cc_version"] = "4.0"
+                case Constants.LICENSE_CC_BY_NC_ND_20:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_NC_ND"
+                    spaces["ccm:commonlicense_cc_version"] = "20"
                 case Constants.LICENSE_CC_BY_NC_ND_30:
                     spaces["ccm:commonlicense_key"] = "CC_BY_NC_ND"
                     spaces["ccm:commonlicense_cc_version"] = "3.0"
                 case Constants.LICENSE_CC_BY_NC_ND_40:
                     spaces["ccm:commonlicense_key"] = "CC_BY_NC_ND"
                     spaces["ccm:commonlicense_cc_version"] = "4.0"
+                case Constants.LICENSE_CC_BY_NC_SA_20:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_NC_SA"
+                    spaces["ccm:commonlicense_cc_version"] = "2.0"
+                case Constants.LICENSE_CC_BY_NC_SA_25:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_NC_SA"
+                    spaces["ccm:commonlicense_cc_version"] = "2.5"
                 case Constants.LICENSE_CC_BY_NC_SA_30:
                     spaces["ccm:commonlicense_key"] = "CC_BY_NC_SA"
                     spaces["ccm:commonlicense_cc_version"] = "3.0"
                 case Constants.LICENSE_CC_BY_NC_SA_40:
                     spaces["ccm:commonlicense_key"] = "CC_BY_NC_SA"
                     spaces["ccm:commonlicense_cc_version"] = "4.0"
+                case Constants.LICENSE_CC_BY_ND_20:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_ND"
+                    spaces["ccm:commonlicense_cc_version"] = "2.0"
                 case Constants.LICENSE_CC_BY_ND_30:
                     spaces["ccm:commonlicense_key"] = "CC_BY_ND"
                     spaces["ccm:commonlicense_cc_version"] = "3.0"
                 case Constants.LICENSE_CC_BY_ND_40:
                     spaces["ccm:commonlicense_key"] = "CC_BY_ND"
                     spaces["ccm:commonlicense_cc_version"] = "4.0"
+                case Constants.LICENSE_CC_BY_SA_20:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_SA"
+                    spaces["ccm:commonlicense_cc_version"] = "2.0"
+                case Constants.LICENSE_CC_BY_SA_25:
+                    spaces["ccm:commonlicense_key"] = "CC_BY_SA"
+                    spaces["ccm:commonlicense_cc_version"] = "2.5"
                 case Constants.LICENSE_CC_BY_SA_30:
                     spaces["ccm:commonlicense_key"] = "CC_BY_SA"
                     spaces["ccm:commonlicense_cc_version"] = "3.0"

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -1,4 +1,5 @@
 import base64
+import collections
 import json
 import logging
 import time
@@ -398,6 +399,12 @@ class EduSharing:
                 spaces["ccm:educationaltypicalagerange_from"] = tar["fromRange"]
             if "toRange" in tar:
                 spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
+
+        # map custom fields directly into the edu-sharing properties
+        if "custom" in item:
+            for key in item["custom"]:
+                spaces[key] = item["custom"][key]
+
         # intendedEndUserRole = Field(output_processor=JoinMultivalues())
         # discipline = Field(output_processor=JoinMultivalues())
         # educationalContext = Field(output_processor=JoinMultivalues())

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -471,6 +471,9 @@ class EduSharing:
                 EduSharing.groupCache.append(result["authorityName"])
 
     def setNodePermissions(self, uuid, item):
+        if env.get_bool("EDU_SHARING_PERMISSION_CONTROL", False, True) == False:
+            logging.debug("Skipping permissions, EDU_SHARING_PERMISSION_CONTROL is set to false")
+            return
         if "permissions" in item:
             permissions = {
                 "inherited": True,  # let inherited = true to add additional permissions via edu-sharing

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -328,6 +328,8 @@ class EduSharing:
         }
         if "notes" in item:
             spaces["ccm:notes"] = item["notes"]
+        if "status" in item:
+            spaces["ccm:editorial_state"] = item["status"]
         if "origin" in item:
             spaces["ccm:replicationsourceorigin"] = item[
                 "origin"

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -400,6 +400,12 @@ class EduSharing:
         }
         for key in item["valuespaces"]:
             spaces[valuespaceMapping[key]] = item["valuespaces"][key]
+        # add raw values if the api supports it
+        if EduSharing.version["major"] >= 1 and EduSharing.version["minor"] >= 1:
+            for key in item["valuespaces_raw"]:
+                splitted = valuespaceMapping[key].split(":")
+                splitted[0] = "virtual"
+                spaces[":".join(splitted)] = item["valuespaces_raw"][key]
         if "typicalAgeRange" in item["lom"]["educational"]:
             tar = item["lom"]["educational"]["typicalAgeRange"]
             if "fromRange" in tar:

--- a/converter/items.py
+++ b/converter/items.py
@@ -194,6 +194,8 @@ class BaseItem(Item):
     "editorial notes"
     binary = Field()
     "binary data which should be uploaded (raw data)"
+    custom = Field()
+    "custom data, it can be used by the target transformer to store data in the native format (i.e. ccm/cclom properties in edu-sharing)"
     screenshot_bytes = Field()
     # this is a (temporary) field that gets deleted after the thumbnail pipeline processed its byte-data
 

--- a/converter/items.py
+++ b/converter/items.py
@@ -195,6 +195,8 @@ class BaseItem(Item):
     publisher = Field()
     notes = Field()
     "editorial notes"
+    status = Field()
+    "status information of a given node, i.e. activated or deactivated"
     binary = Field()
     "binary data which should be uploaded (raw data)"
     custom = Field()

--- a/converter/items.py
+++ b/converter/items.py
@@ -32,7 +32,7 @@ class MutlilangItem(Item):
 
 
 class LomGeneralItem(Item):
-    identifier = Field()
+    identifier = Field(output_processor=JoinMultivalues())
     title = Field()
     language = Field()
     keyword = Field(output_processor=JoinMultivalues())

--- a/converter/items.py
+++ b/converter/items.py
@@ -186,6 +186,9 @@ class BaseItem(Item):
     lastModified = Field()
     lom = Field(serializer=LomBaseItem)
     valuespaces = Field(serializer=ValuespaceItem)
+    "all items which are based on (skos) based valuespaces. The ProcessValuespacePipeline will automatically convert items inside here"
+    valuespaces_raw = Field(serializer=ValuespaceItem)
+    "this item is only used by the ProcessValuespacePipeline and holds the ""raw"" data which were given to the valuespaces. Please do not use it inside crawlers"
     permissions = Field(serializer=PermissionItem)
     "permissions (access rights) for this entry"
     license = Field(serializer=LicenseItem)

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -269,6 +269,7 @@ class ProcessValuespacePipeline(BasicPipeline):
     def process_item(self, raw_item, spider):
         item = ItemAdapter(raw_item)
         json = item["valuespaces"]
+        item["valuespaces_raw"] = dict(json)
         delete = []
         for key in json:
             # remap to new i18n layout

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -691,6 +691,7 @@ class LisumPipeline(BasicPipeline):
         "480": "C-PB",  # Politische Bildung
         "510": "C-Psy",  # Psychologie
         "520": "C-LER",  # Religion -> Lebensgestaltung-Ethik-Religionskunde
+        # ToDo: 560 -> "C-NW56-3-8" ? (Sexualerziehung)
         "700": "C-SOWI",  # Wirtschaftskunde -> "Sozialwissenschaft/Wirtschaftswissenschaft"
         "12002": "C-Thea",  # Darstellendes Spiel, Schultheater -> Theater
         "20001": "C-EN",  # Englisch
@@ -699,6 +700,7 @@ class LisumPipeline(BasicPipeline):
         "20004": "C-IT",  # Italienisch
         "20005": "C-La",  # Latein
         "20006": "C-RU",  # Russisch
+        "20007": "C-ES",  # Spanisch
         "20008": "C-TR",  # Türkisch
         "20011": "C-PL",  # Polnisch
         "20014": "C-PT",  # Portugiesisch

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -723,24 +723,12 @@ class LisumPipeline(BasicPipeline):
     }
 
     LRT_OEH_TO_LISUM = {
-        # ToDo: LRT-values that aren't listed here, can be mapped 1:1
+        # LRT-values that aren't listed here, can be mapped 1:1
         "audiovisual_medium": ["audio", "video"],
-        # ToDo: BROSCHUERE?
-        "data": "",  # ToDo
-        "exploration": "",  # ToDo
-        "case_study": "",  # ToDo
-        "glossary": "reference_book",
-        "guide": "reference_book",
         # ToDo: INTERAKTION
-        "model": "",  # ToDo
-        "open_activity": "",  # ToDo
+        "open_activity": "",  # exists in 2 out of 60.000 items
         "broadcast": "audio",
-        "enquiry_oriented_activity": "",  # ToDo
-        "other": "",  # ToDo
-        "text": "teaching_aids",  # teaching_aids = "Arbeitsmaterial" in Lisum mds
-        "teaching_module": "",  # ToDo
         "demonstration": "image",  # "Veranschaulichung"
-        "web_page": "portal",
     }
 
     def process_item(self, item: BaseItem, spider: scrapy.Spider) -> Optional[scrapy.Item]:

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -662,3 +662,11 @@ class DummyPipeline(BasicPipeline):
         log.info("DRY RUN scraped {}".format(item["response"]["url"]))
         # self.exporter.export_item(item)
         return item
+
+
+# example pipeline which simply outputs the item in the log
+class ExampleLoggingPipeline(BasicPipeline):
+    def process_item(self, item, spider):
+        log.info(item)
+        # self.exporter.export_item(item)
+        return item

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -675,6 +675,7 @@ class ExampleLoggingPipeline(BasicPipeline):
 
 class LisumPipeline(BasicPipeline):
     DISCIPLINE_TO_LISUM = {
+        "020": "C-WAT",  # Arbeitslehre -> Wirtschaft, Arbeit, Technik
         "060": "C-KU",  # Bildende Kunst
         "080": "C-BIO",  # Biologie
         "100": "C-CH",  # Chemie
@@ -698,10 +699,15 @@ class LisumPipeline(BasicPipeline):
         "20004": "C-IT",  # Italienisch
         "20005": "C-La",  # Latein
         "20006": "C-RU",  # Russisch
+        "20008": "C-TR",  # Türkisch
+        "20011": "C-PL",  # Polnisch
+        "20014": "C-PT",  # Portugiesisch
+        "20041": "C-ZH",  # Chinesisch
         "28010": "C-SU",  # Sachkunde -> Sachunterricht
         "32002": "C-Inf",  # Informatik
         "46014": "C-AS",  # Astronomie
         "48005": "C-GEWIWI",  # Gesellschaftspolitische Gegenwartsfragen -> Gesellschaftswissenschaften
+        "2800506": "C-PL",  # Polnisch
     }
 
     EDUCATIONALCONTEXT_TO_LISUM = {
@@ -747,14 +753,8 @@ class LisumPipeline(BasicPipeline):
         - valuespaces.learningResourceType
         """
         base_item_adapter = ItemAdapter(item)
-        # ToDo:
-        #   - map ValueSpaceItem.discipline from SKOS to ccm:taxonid keys
-        #       - e.g. "Astronomie" (eafCode: 46014) to "C-AS"
-        #       - after the "valuespaces"-mapping,
-        #       a discipline looks like 'http://w3id.org/openeduhub/vocabs/discipline/380' -> eafCode at the end
-        #       from 380 ("Mathematik") map to "C-MA"
-        #   - make sure that discipline.ttl has all possible values, otherwise information loss occurs
-        #   - keep raw list for debugging purposes?
+        # ToDo: - make sure that discipline.ttl has all possible values, otherwise information loss occurs
+        #       - keep raw list for debugging purposes?
         if base_item_adapter.get("valuespaces"):
             valuespaces = base_item_adapter.get("valuespaces")
             if valuespaces.get("discipline"):
@@ -762,6 +762,7 @@ class LisumPipeline(BasicPipeline):
                 # a singular entry will look like 'http://w3id.org/openeduhub/vocabs/discipline/380'
                 # the last part of the URL string equals to a corresponding eafCode
                 # (see: http://agmud.de/wp-content/uploads/2021/09/eafsys.txt)
+                # this eafCode (key) gets mapped to Lisum specific B-B shorthands like "C-MA"
                 discipline_lisum_keys = set()
                 if discipline_list:
                     for discipline_w3id in discipline_list:
@@ -769,21 +770,14 @@ class LisumPipeline(BasicPipeline):
                         match discipline_eaf_code in self.DISCIPLINE_TO_LISUM:
                             case True:
                                 discipline_lisum_keys.add(self.DISCIPLINE_TO_LISUM.get(discipline_eaf_code))
-                            case False:
-                                # ToDo: missing Sodix values for mapping to
-                                #  - Chinesisch (C-ZH)
+                                # ToDo: there are no Sodix eafCode-values for these Lisum keys:
                                 #  - Deutsche Gebärdensprache (C-DGS)
                                 #  - Hebräisch (C-HE)
                                 #  - Japanisch (C-JP)
                                 #  - Naturwissenschaften (5/6) (= C-NW56)
                                 #  - Naturwissenschaften (C-NW)
                                 #  - Neu Griechisch (C-EL)
-                                #  - Polnisch (C-PL)
-                                #  - Portugiesisch (C-PT)
                                 #  - Sorbisch/Wendisch (C-SW)
-                                #  - Türkisch (C-TR)
-                                #  - Wirtschaft-Arbeit-Technik (C-WAT)
-                                pass
                             case _:
                                 # ToDo: fallback -> if eafCode can't be mapped, save to keywords?
                                 logging.warning(f"Lisum Pipeline failed to map from eafCode {discipline_eaf_code} "
@@ -856,7 +850,6 @@ class LisumPipeline(BasicPipeline):
                     lrt_list = lrt_temporary_list
                     lrt_list.sort()
                     valuespaces["learningResourceType"] = lrt_list
-                pass
-            # ToDo: learningResourceType
+        # ToDo: which fields am I missing? what's next?
 
         return item

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -743,6 +743,12 @@ class LisumPipeline(BasicPipeline):
         base_item_adapter = ItemAdapter(item)
         # ToDo: - make sure that discipline.ttl has all possible values, otherwise information loss occurs
         #       - keep raw list for debugging purposes?
+        if base_item_adapter.get("custom"):
+            custom_field = base_item_adapter.get("custom")
+            # ToDo: handling or extending this field might or might not be necessary in the future
+            if "ccm:taxonentry" in custom_field:
+                pass
+            pass
         if base_item_adapter.get("valuespaces"):
             valuespaces = base_item_adapter.get("valuespaces")
             if valuespaces.get("discipline"):

--- a/converter/settings.py
+++ b/converter/settings.py
@@ -120,6 +120,12 @@ ITEM_PIPELINES = {
     ): 1000,
 }
 
+# add custom pipelines from the .env file, if any
+ADDITIONAL_PIPELINES = env.get("CUSTOM_PIPELINES", True)
+if ADDITIONAL_PIPELINES:
+    for pipe in map(lambda p: p.split(":"), ADDITIONAL_PIPELINES.split(",")):
+        ITEM_PIPELINES[pipe[0]] = int(pipe[1])
+
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
 AUTOTHROTTLE_ENABLED = False

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -11,6 +11,18 @@ from .base_classes import LomBase
 from .. import env
 from ..items import LomLifecycleItemloader
 
+import csv
+import json
+
+# Opening JSON file
+f = open('results.json')
+# returns JSON object as
+# a dictionary
+data = json.load(f)
+with open('mycsvfile.csv', 'w') as f:  # You will need 'wb' mode in Python 2.x
+    w = csv.DictWriter(f, data.keys())
+    w.writeheader()
+    w.writerow(data)
 
 def extract_eaf_codes_to_set(eaf_code_list: list[str]) -> set:
     """
@@ -313,6 +325,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         base.add_value("status", self.get("recordStatus", json=response.meta["item"]))
         last_modified = self.get("updated", json=response.meta["item"])
         if last_modified:
+
             base.add_value('lastModified', last_modified)
         # ToDo: (optional feature) use 'source'-field from the GraphQL item for 'origin'?
         source_id: str = self.get("source.id", json=response.meta["item"])
@@ -712,7 +725,8 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             if "UNTERRICHTSBAUSTEIN" in potential_lrts:
                 general.add_value('aggregationLevel', 2)
             if "INTERAKTION" in potential_lrts and env.get(key='CUSTOM_PIPELINES', allow_null=True) is not None:
-                if "LisumPipeline" in env.get(key='CUSTOM_PIPELINES', allow_null=True):
+                # TODO: Do such logic in a pipeline, not in the crawler!
+                if "LisumPipeline" in env.get(key='CUSTOM_PIPELINES', allow_null=True, default=None):
                     base.add_value('custom', {'sodix_lisum_lrt': 'interactive_material'})
 
         technical = self.getLOMTechnical(response)

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -310,6 +310,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         #         "publisher", publisher['title']
         #     )
         # ToDo: the 'publisher'-field in BaseItem will be removed in the future
+        base.add_value("status", self.get("recordStatus", json=response.meta["item"]))
         last_modified = self.get("updated", json=response.meta["item"])
         if last_modified:
             base.add_value('lastModified', last_modified)

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -710,8 +710,9 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         if potential_lrts:
             if "UNTERRICHTSBAUSTEIN" in potential_lrts:
                 general.add_value('aggregationLevel', 2)
-            if "INTERAKTION" in potential_lrts and "LisumPipeline" in env.get(key='CUSTOM_PIPELINES'):
-                base.add_value('custom', {'sodix_lisum_lrt': ['interactive_material']})
+            if "INTERAKTION" in potential_lrts and env.get(key='CUSTOM_PIPELINES', allow_null=True) is not None:
+                if "LisumPipeline" in env.get(key='CUSTOM_PIPELINES', allow_null=True):
+                    base.add_value('custom', {'sodix_lisum_lrt': 'interactive_material'})
 
         technical = self.getLOMTechnical(response)
         if self.get("author", json=response.meta["item"]):

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -556,7 +556,10 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                     # e.g. a license pointing to v3.0 and v4.0 at the same time)
                     pass
                 else:
-                    license_loader.add_value('url', license_mapped_url)
+                    if license_mapped_url in [Constants.LICENSE_COPYRIGHT_LAW]:
+                        license_loader.add_value('internal', license_mapped_url)
+                    else:
+                        license_loader.add_value('url', license_mapped_url)
                     if not license_description:
                         # "name"-fields with the "Copyright, freier Zugang"-value don't have "text"-fields, therefore
                         # we're carrying over the custom description, just in case

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -546,6 +546,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                         license_loader.replace_value('description', license_name)
 
         license_url: str = self.get("license.url", json=response.meta["item"])
+        # possible license URL values returned by the Sodix API:
         # license_urls_sorted = ['https://creativecommons.org/licenses/by-nc-nd/2.0/de/',
         #                        'https://creativecommons.org/licenses/by-nc-nd/3.0/de/',
         #                        'https://creativecommons.org/licenses/by-nc-nd/3.0/deed.de',
@@ -576,7 +577,6 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         #                        'https://creativecommons.org/licenses/by/4.0/',
         #                        'https://creativecommons.org/publicdomain/mark/1.0/deed.de',
         #                        'https://creativecommons.org/publicdomain/zero/1.0/deed.de']
-        # ToDo: our constants.py doesn't have entries for v2.0 or 2.5 values of CC licenses
         if license_url:
             # making sure to only handle valid license urls, since the API result can be NoneType or empty string ('')
             if license_url.endswith("deed.de"):

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -35,7 +35,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
     name = "sodix_spider"
     friendlyName = "Sodix"
     url = "https://sodix.de/"
-    version = "0.2.1"  # last update: 2022-10-11
+    version = "0.2.2"  # last update: 2022-10-11
     apiUrl = "https://api.sodix.de/gql/graphql"
     page_size = 2500
     custom_settings = {
@@ -653,6 +653,8 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         if potential_lrts:
             if "UNTERRICHTSBAUSTEIN" in potential_lrts:
                 general.add_value('aggregationLevel', 2)
+            if "INTERAKTION" in potential_lrts:
+                base.add_value('custom', {'sodix_lisum_lrt': ['interactive_material']})
 
         technical = self.getLOMTechnical(response)
         if self.get("author", json=response.meta["item"]):

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -500,7 +500,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             "location", self.getUri(response)
         )
         original = self.get("media.originalUrl", json=response.meta["item"])
-        if original:
+        if original and self.getUri(response) != original:
             technical.add_value(
                 "location", original
             )

--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -324,8 +324,9 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                 if "id" in publisher:
                     publisher_sodix_uuid: str = publisher.get("id")
                     if publisher_sodix_uuid:
+                        # this uuid is used by Sodix to differentiate publishers
                         lifecycle.add_value('uuid', publisher_sodix_uuid)
-                if "officialWebsite" in publishers:
+                if "officialWebsite" in publisher:
                     publisher_url: str = publisher.get("officialWebsite")
                     if publisher_url:
                         lifecycle.add_value('url', publisher_url)
@@ -590,6 +591,13 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
 
         lom = LomBaseItemloader()
         general = self.getLOMGeneral(response)
+
+        # "UNTERRICHTSBAUSTEIN"-Materials need to handled as aggregationLevel = 2 (according to LOM-DE)
+        potential_lrts = self.get('learnResourceType', json=response.meta['item'])
+        if potential_lrts:
+            if "UNTERRICHTSBAUSTEIN" in potential_lrts:
+                general.add_value('aggregationLevel', 2)
+
         technical = self.getLOMTechnical(response)
         if self.get("author", json=response.meta["item"]):
             lifecycle_author = self.get_lom_lifecycle_author(response)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - "PLAYWRIGHT_WS_ENDPOINT=ws://headless_chrome:3000"
       - "SPLASH_URL=http://splash:8050"
       - "CRAWLER=${CRAWLER}"
+      # optional keyword args, e.g. cleanrun=true
+      - "ARGS=${ARGS}"
       - "DRY_RUN=False"
       - "LOG_LEVEL=${LOG_LEVEL:-INFO}"
       - "EDU_SHARING_BASE_URL=${EDU_SHARING_BASE_URL}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$ARGS" ]
+then
+  scrapy crawl "$CRAWLER"
+else
+  scrapy crawl -a "$ARGS" "$CRAWLER"
+fi
+


### PR DESCRIPTION
During the OER Sommercamp 2022 the following changes were made to the `sodix_spider` to enable filtering of OER-materials **prior** to saving them within an edu-sharing repo.

A "normal" crawl expects ~58.125 (as of 2022-08-24) Items to be crawled from SODIX. During the first test-run of the crawler, it was observed that 47774 of those materials were not-OER-compatbile materials, therefore skipped from crawling when `oer_filter=True`. The crawler gathered 10.080 **OER-only** Items with clear and concise license information from the SODIX API.

### Changelog:
- add: oer_filter
-- controllable via global variable OER_FILTER (default: False)
--- either use **spider arguments** or the **`.env`-file** to set the desired behavior
- by using the OER-Filter only OER-materials get crawled (all other (copyright/ambiguous) licenses are skipped while crawling)