### PR TITLE
ZUM Crawlers: URL-encoding Bugfixes

### DIFF
--- a/.run/zum_spider.run.xml
+++ b/.run/zum_spider.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="zum_spider" type="PythonConfigurationType" factoryName="Python">
+    <output_file path="$PROJECT_DIR$/logs/zum_spider_console.log" is_save="true" />
+    <module name="oeh-search-etl" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/converter/spiders" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="scrapy.cmdline" />
+    <option name="PARAMETERS" value="crawl zum_spider -O &quot;../../logs/zum_spider.json&quot;" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="true" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/converter/spiders/base_classes/mediawiki_base.py
+++ b/converter/spiders/base_classes/mediawiki_base.py
@@ -206,7 +206,10 @@ class MediaWikiBase(LomBase, metaclass=SpiderBase):
     def mapResponse(self, response, fetchData=True):
         mr = super().mapResponse(response, fetchData=False)
         data = json.loads(response.body)
-        mr.replace_value('url', f'{self.url}wiki/{jmes_title.search(data)}')
+        title = jmes_title.search(data)
+        mr.replace_value('url', f"{self.url}{urllib.parse.quote('wiki/')}{urllib.parse.quote(title)}")
+        # response.url can't be used for string concatenation here since it would point to "/api.php"
+        # self.url is overwritten by the children of MediaWikiBase with the URL root
         return mr
 
     def getBase(self, response=None) -> BaseItemLoader:
@@ -240,7 +243,7 @@ class MediaWikiBase(LomBase, metaclass=SpiderBase):
         loader.replace_value('format', 'text/html')
         data = response.meta['item']
         title = jmes_title.search(data)
-        loader.replace_value('location', f'{self.url}wiki/{urllib.parse.quote(title)}')
+        loader.replace_value('location', f"{self.url}{urllib.parse.quote('wiki/')}{urllib.parse.quote(title)}")
         return loader
 
     def getValuespaces(self, response):

--- a/converter/spiders/zum_deutschlernen.py
+++ b/converter/spiders/zum_deutschlernen.py
@@ -11,7 +11,7 @@ class ZUMSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_deutschlernen_spider"
     friendlyName = "ZUM-Deutsch-Lernen"
     url = "https://deutsch-lernen.zum.de/"
-    version = "0.1.0"
+    version = "0.1.1"  # last update: 2022-09-13
     license = Constants.LICENSE_CC_BY_40
 
     def parse_page_query(self, response: scrapy.http.Response):

--- a/converter/spiders/zum_klexikon.py
+++ b/converter/spiders/zum_klexikon.py
@@ -14,7 +14,7 @@ class ZUMKlexikonSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_klexikon_spider"
     friendlyName = "ZUM-Klexikon"
     url = "https://klexikon.zum.de/"
-    version = "0.1.2"  # last update: 2022-02-16
+    version = "0.1.3"  # last update: 2022-09-13
     license = Constants.LICENSE_CC_BY_SA_30
 
     def parse_page_query(self, response: scrapy.http.Response):

--- a/converter/spiders/zum_spider.py
+++ b/converter/spiders/zum_spider.py
@@ -11,7 +11,7 @@ class ZUMSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_spider"
     friendlyName = "ZUM-Unterrichten"
     url = "https://unterrichten.zum.de/"
-    version = "0.1.0"
+    version = "0.1.1"  # last update: 2022-09-13
     license = Constants.LICENSE_CC_BY_SA_40
 
     def technical_item(self, response=None) -> LomTechnicalItem:


### PR DESCRIPTION
MediaWikiBase gathered URLs by collecting titles from the ZUM API and assembling them manually. Special characters weren't properly encoded therefore caused malformed links in edu-sharing (`cclom:location_status: 900`).

- Implemented fixes for `base.url` and `technical.location` in `MediaWikiBase`
- version bumped `zum_spider`, `zum_klexikon_spider` and `zum_deutschlernen` to force an overwrite of problematic metadata fields

---
Please start these crawlers so the (previously malformed) URLs get updated in edu-sharing:
- [ ] `zum_spider`
- [ ] `zum_klexikon_spider`
- [ ] `zum_deutschlernen`