### PR TITLE
remove: "Schülerhilfe" from YouTube crawling

### DIFF
--- a/csv/youtube.csv
+++ b/csv/youtube.csv
@@ -35,7 +35,6 @@ https://www.youtube.com/channel/UCNOsl2b57wNgN7l13TOzNJQ/featured,Jule Sommersbe
 https://www.youtube.com/channel/UCV9AcuxBK-W3ejgsDm35W1w/feed,seguGeschichte,video,240,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
 https://www.youtube.com/channel/UCJWn5X9X50U0kcNCgBou7EA/featured,YoungBusinessSchool,video,380; 04003; 700,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
 https://www.youtube.com/channel/UCHCip3cKoCIkpfeYDV7-aLg/featured,Lernkiste - Mathematik,video,380,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
-https://www.youtube.com/channel/UCpdCp55K5WwVYiRRKyxKoWQ/featured,Schülerhilfe,video,380; 120; 20001,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
 https://www.youtube.com/channel/UCy0FxMgGUlRnkxCoNZUNRQQ/featured,Lehrerschmidt ,video,380,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
 https://www.youtube.com/channel/UCPVQdTsc9O0VM41vAhdlVLw/featured,ObachtMathe,video,380,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,18,de,,
 https://www.youtube.com/channel/UCO7ksLK-11tVxalfPKf7BTQ/featured,Primartorium,video,380,Primarstufe; Sekundarstufe 1,learner; teacher,6,13,de,,


### PR DESCRIPTION
- due to a decision made on 2021-09-23 (for context: check the "Fachredaktionsleitungskonferenz"-protocol) the YT-channel "Schülerhilfe" will no longer be crawled by the youtube_spider 
    - this decision was brought up and confirmed on 2022-09-14 ("Inhaltekonferenz")