### PR TITLE
change: zum_dwu_spider to dwu_spider (v0.0.6)

### DIFF
--- a/.run/dwu_spider.run.xml
+++ b/.run/dwu_spider.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="zum_dwu_spider" type="PythonConfigurationType" factoryName="Python">
-    <output_file path="$PROJECT_DIR$/logs/zum_dwu_spider_console.log" is_save="true" />
+  <configuration default="false" name="dwu_spider" type="PythonConfigurationType" factoryName="Python">
+    <output_file path="$PROJECT_DIR$/logs/dwu_spider_console.log" is_save="true" />
     <module name="oeh-search-etl" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
@@ -14,7 +14,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="scrapy.cmdline" />
-    <option name="PARAMETERS" value="crawl zum_dwu_spider -O &quot;../../logs/zum_dwu_spider.json&quot;" />
+    <option name="PARAMETERS" value="crawl dwu_spider -O &quot;../../logs/dwu_spider.json&quot;" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />


### PR DESCRIPTION
For further information, please check [SD_WLO-525](https://issues.edu-sharing.net/jira/browse/SD_WLO-525)

- [ ] After merging this branch, please also merge https://github.com/openeduhub/oeh-metadata-vocabs/pull/32 to update the `sources.ttl`-entry.

Changelog-Summary:
- changes due to SD_WLO-525:
-- this crawler update was necessary due to a request from DWU who informed us that DWU learning materials won't be available anymore on ZUM servers in the near future
-- therefore changing URLs (from ZUM URLs to DWU's private website offering)
- fix: additional check for empty "title"-strings
- improve: license.description, lifecycle.organization, lifecycle.url
-- hard-coded some values since they are not occurring regularly on every HTML, but are (most probably) meant to be
- fix: slightly more generous XPath expressions for sections and subtopics
-- the DOM structure seems to have slightly changed since the last time the crawler ran, therefore I changed the XPaths to be slightly more generous during link collection
- version bump to v0.0.5
-- renamed `zum_dwu_spider` to `dwu_spider` (class, filename and `name`-value)