### PR TITLE
youtube_spider: (optional) feature - limited crawls to a specific URL

### DIFF
--- a/converter/.env.example
+++ b/converter/.env.example
@@ -40,8 +40,11 @@ DRY_RUN = True
 # Use this if you e.g. want to do custom property mapping for any crawler before storing the data
 # CUSTOM_PIPELINES = "converter.pipelines.ExampleLoggingPipeline:100"
 
-# your youtube api key (required for youtube crawler)
-YOUTUBE_API_KEY = ""
+# Your YouTube API key (required for running the youtube crawler 'youtube_spider'):
+YOUTUBE_API_KEY=""
+# If you only want to crawl a single YouTube channel/playlist, activate the LIMITED crawl mode by setting its URL here:
+#YOUTUBE_LIMITED_CRAWL_URL=""
+# (Please make sure that your 'csv/youtube.csv' contains the same URL!)
 
 # only for oeh spider: select the sources you want to fetch from oeh (comma seperated)
 # OEH_IMPORT_SOURCES = 'oeh,wirlernenonline_spider,serlo_spider,youtube_spider'

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -300,7 +300,7 @@ class EduSharing:
                     if "description" in license:
                         spaces["cclom:rights_description"] = license["description"]
                 case _:
-                    logging.warning(f"Received a value for license['internal'] that is not recognized by es_connector."
+                    logging.warning(f"Received a value for license['internal'] that is not recognized by es_connector. "
                                     f"Please double-check if the provided value {license['internal']} is correctly "
                                     f"mapped within Constants AND es_connector.")
 


### PR DESCRIPTION
This PR implements the feature-request (Jira: DESP-913) for the YouTube-Crawler: **optional**, singular crawling of parametrized URLs. The default behavior of the crawler (if no environment variable for a limited crawl is set) stays the same.

### Workflow
If the YouTube-Crawler should only do a singular crawl of a specific URL, there are **two preconditions** to activate the "limited" crawl mode:

1. The `.env`-file must contain a variable called `YOUTUBE_LIMITED_CRAWL_URL` which is set to the to-be-crawled URL.
2. The `csv/youtube.csv`-file must contain a line with the **exact** URL and the to-be-set metadata values for all objects

`.env`-example (for YouTube channel Ecole Science): `YOUTUBE_LIMITED_CRAWL_URL="https://www.youtube.com/channel/UC1a400owZ_Qa-3Ood22cMKg"`