### PR TITLE
change: use playwright for ZUM (MediaWikiBase) crawlers

### DIFF
--- a/converter/spiders/zum_deutschlernen.py
+++ b/converter/spiders/zum_deutschlernen.py
@@ -5,14 +5,18 @@ from .base_classes import MediaWikiBase
 import scrapy
 
 from ..constants import Constants
+from ..web_tools import WebEngine
 
 
 class ZUMSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_deutschlernen_spider"
     friendlyName = "ZUM-Deutsch-Lernen"
     url = "https://deutsch-lernen.zum.de/"
-    version = "0.1.1"  # last update: 2022-09-13
+    version = "0.1.2"  # last update: 2023-01-05
     license = Constants.LICENSE_CC_BY_40
+    custom_settings = {
+        "WEB_TOOLS": WebEngine.Playwright
+    }
 
     def parse_page_query(self, response: scrapy.http.Response):
         """

--- a/converter/spiders/zum_klexikon.py
+++ b/converter/spiders/zum_klexikon.py
@@ -5,17 +5,21 @@ import scrapy
 import w3lib.html
 from scrapy import Selector
 
-from converter.items import LomTechnicalItem, LicenseItem, LomGeneralItemloader, ValuespaceItemLoader, ValuespaceItem
+from converter.items import LomTechnicalItem, LicenseItem, LomGeneralItemloader, ValuespaceItem
 from .base_classes.mediawiki_base import MediaWikiBase, jmes_pageids, jmes_title, jmes_links, jmes_continue
 from ..constants import Constants
+from ..web_tools import WebEngine
 
 
 class ZUMKlexikonSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_klexikon_spider"
     friendlyName = "ZUM-Klexikon"
     url = "https://klexikon.zum.de/"
-    version = "0.1.3"  # last update: 2022-09-13
-    license = Constants.LICENSE_CC_BY_SA_30
+    version = "0.1.4"  # last update: 2023-01-05
+    license = Constants.LICENSE_CC_BY_SA_40
+    custom_settings = {
+        "WEB_TOOLS": WebEngine.Playwright
+    }
 
     def parse_page_query(self, response: scrapy.http.Response):
         """

--- a/converter/spiders/zum_spider.py
+++ b/converter/spiders/zum_spider.py
@@ -5,14 +5,18 @@ import scrapy
 from converter.constants import Constants
 from converter.items import LicenseItem, LomTechnicalItem, ValuespaceItem, LomGeneralItem
 from converter.spiders.base_classes import MediaWikiBase
+from converter.web_tools import WebEngine
 
 
 class ZUMSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_spider"
     friendlyName = "ZUM-Unterrichten"
     url = "https://unterrichten.zum.de/"
-    version = "0.1.1"  # last update: 2022-09-13
+    version = "0.1.2"  # last update: 2023-01-05
     license = Constants.LICENSE_CC_BY_SA_40
+    custom_settings = {
+        "WEB_TOOLS": WebEngine.Playwright
+    }
 
     def technical_item(self, response=None) -> LomTechnicalItem:
         """
@@ -41,4 +45,3 @@ class ZUMSpider(MediaWikiBase, scrapy.Spider):
         @scrapes discipline educationalContext intendedEndUserRole
         """
         return self.getValuespaces(response).load_item()
-


### PR DESCRIPTION
(see: [SD_WLO-419](https://issues.edu-sharing.net/jira/browse/SD_WLO-419))

- during testing of the recent ZUM URL-encoding fixes (SD_WLO-419) it was noticed that crawlers waited for Splash containers (which never recovered from hanging) indefinitely in the ranger environment 
   - therefore added custom_settings to use Playwright instead
- version bump `zum_deutschlernen.py`, `zum_spider.py` and `zum_klexikon.py` to refresh their metadata during the next crawl

zum_klexikon:
- fix: changed license from CC-BY-SA 3.0 to 4.0 
    - Klexikon seems to have switched its license version sometime in the past, according to its DOM (footer)