### PR TITLE
feat: academic titles (lifecycle)

### DIFF
--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -384,6 +384,7 @@ class EduSharing:
                 # convert to a vcard string
                 firstName = person["firstName"] if "firstName" in person else ""
                 lastName = person["lastName"] if "lastName" in person else ""
+                title: str = person["title"] if "title" in person else ""
                 organization = (
                     person["organization"] if "organization" in person else ""
                 )
@@ -399,6 +400,8 @@ class EduSharing:
                     if organization
                     else (firstName + " " + lastName).strip()
                 )
+                if title:
+                    vcard.add("title").value = title
                 if date:
                     vcard.add("X-ES-LOM-CONTRIBUTE-DATE").value = date.isoformat()
                     if person["role"].lower() == 'publisher':

--- a/converter/items.py
+++ b/converter/items.py
@@ -72,17 +72,20 @@ class LomLifecycleItem(Item):
 
     The role 'unknown' is used for contributors in an unknown capacity ("Mitarbeiter").
     """
-    role = Field()
+    date = Field()
+    """The (publication) date of a contribution. Date values will be automatically transformed/parsed.
+    Corresponding edu-sharing property: 'ccm:published_date'"""
+    email = Field()
     firstName = Field()
     lastName = Field()
     organization = Field()
-    email = Field()
+    role = Field()
+    title = Field()
+    """The (academic) title of a person. String value will be prefixed to '(title) firstName lastName' and written into
+    the vCard-field 'TITLE'.
+    """
     url = Field()
     uuid = Field()
-    date = Field()
-    """The (publication) date of a contribution. Date values will be automatically transformed/parsed.
-    Corresponding edu-sharing property: 'ccm:published_date'
-    """
 
 
 class LomTechnicalItem(Item):

--- a/converter/spiders/base_classes/edu_sharing_base.py
+++ b/converter/spiders/base_classes/edu_sharing_base.py
@@ -193,6 +193,10 @@ class EduSharingBase(Spider, LomBase):
             lifecycle.add_value("role", role)
             lifecycle.add_value("firstName", given)
             lifecycle.add_value("lastName", family)
+        # ToDo: test the 'title'-field before activating it
+        # if hasattr(vcard, "title"):
+        #     title: str = vcard.title.value
+        #     lifecycle.add_value("title", title)
         if hasattr(vcard, "email"):
             # ToDo: recognize multiple emails
             vcard_email: str = vcard.email.value


### PR DESCRIPTION
OERSI provides an (optional) field called `honorificPrefix`, which contains description strings for academic titles.

- I implemented a `title` field within our `LifecycleItem` which takes this string and saves it to the vCard field `TITLE`
- the `honorificPrefix`-field is an optional sub-field of OERSI's `creator` or `contributor` field
    - some metadata-providers provide weird/invalid values for this field. Therefore I implemented a basic check for known edge-cases that I have encountered during testing

---
Since I didn't want to cause side-effects for `oeh_spider`, this field isn't activated yet in `edu_sharing_base.py` until I had the chance to test it.