### PR TITLE
Feat lifecycle identifiers

### DIFF
--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -391,6 +391,10 @@ class EduSharing:
                 url = person["url"] if "url" in person else ""
                 email = person["email"] if "email" in person else ""
                 date = person["date"] if "date" in person else None
+                id_gnd: str = person["id_gnd"] if "id_gnd" in person else ""
+                id_orcid: str = person["id_orcid"] if "id_orcid" in person else ""
+                id_ror: str = person["id_ror"] if "id_ror"  in person else ""
+                id_wikidata: str = person["id_wikidata"] if "id_wikidata" in person else ""
                 vcard = vobject.vCard()
                 vcard.add("n").value = vobject.vcard.Name(
                     family=lastName, given=firstName
@@ -400,6 +404,14 @@ class EduSharing:
                     if organization
                     else (firstName + " " + lastName).strip()
                 )
+                if id_gnd:
+                    vcard.add("X-GND-URI").value = id_gnd
+                if id_orcid:
+                    vcard.add("X-ORCID").value = id_orcid
+                if id_ror:
+                    vcard.add("X-ROR").value = id_ror
+                if id_wikidata:
+                    vcard.add("X-Wikidata").value = id_wikidata
                 if title:
                     vcard.add("title").value = title
                 if date:

--- a/converter/items.py
+++ b/converter/items.py
@@ -86,6 +86,19 @@ class LomLifecycleItem(Item):
     """
     url = Field()
     uuid = Field()
+    id_gnd = Field()
+    """The GND identifier (URI) of a PERSON, e.g. "https://d-nb.info/gnd/<identifier>". 
+    Values will be written into the vCard namespace 'X-GND-URI'."""
+    id_orcid = Field()
+    """The ORCID identifier (URI) of a PERSON, e.g. "https://orcid.org/<identifier>". 
+    Values will be written into the vCard namespace 'X-ORCID'."""
+    id_ror = Field()
+    """The ROR identifier (URI) of an ORGANIZATION, e.g. "https://ror.org/<identifier>".
+    Values will be written into the vCard namespace 'X-ROR'."""
+    id_wikidata = Field()
+    """The Wikidata identifier (URI) of an ORGANIZATION, e.g. "https://www.wikidata.org/wiki/<identifier>". 
+    Values will be written into the vCard namespace 'X-Wikidata'."""
+
 
 
 class LomTechnicalItem(Item):

--- a/converter/spiders/base_classes/edu_sharing_base.py
+++ b/converter/spiders/base_classes/edu_sharing_base.py
@@ -197,6 +197,15 @@ class EduSharingBase(Spider, LomBase):
         # if hasattr(vcard, "title"):
         #     title: str = vcard.title.value
         #     lifecycle.add_value("title", title)
+        # ToDo: implement identifiers (GND / ORCID / ROR / Wikidata)
+        # if hasattr(vcard, "x-gnd-uri"):
+        #     pass
+        # if hasattr(vcard, "x-orcid"):
+        #     pass
+        # if hasattr(vcard, "x-ror"):
+        #     pass
+        # if hasattr(vcard, "x-wikidata"):
+        #     pass
         if hasattr(vcard, "email"):
             # ToDo: recognize multiple emails
             vcard_email: str = vcard.email.value

--- a/converter/spiders/sample_spider_alternative.py
+++ b/converter/spiders/sample_spider_alternative.py
@@ -133,6 +133,11 @@ class SampleSpiderAlternative(CrawlSpider, LomBase):
         #  - organization                   optional
         #  - email                          optional
         #  - uuid                           optional
+        #  - title                          optional (academic title)
+        #  - id_gnd                         optional (expected: URI)
+        #  - id_orcid                       optional (expected: URI)
+        #  - id_ror                         optional (expected: URI)
+        #  - id_wikidata                    optional (expected: URI)
         lifecycle.add_value('role', 'author')
         # supported roles:
         #   "author" / "editor" / "publisher" / "metadata_contributor" / "metadata_provider" / "unknown"

--- a/converter/util/license_mapper.py
+++ b/converter/util/license_mapper.py
@@ -156,6 +156,10 @@ class LicenseMapper:
                 if regex_deed_hit:
                     deed_hit = regex_deed_hit.group()
                     license_url_candidate = license_url_candidate[: -len(deed_hit)]
+            # ToDo: while it (thankfully) hasn't happened yet, we have to assume that URLs ending in "/fr/" or "/es"
+            #  could be problematic as well. Therefore: refactor the if-checks for "/de/" and "/de" asap
+            if license_url_candidate.endswith("/de"):
+                license_url_candidate = license_url_candidate[: -len("de")]
             if license_url_candidate.endswith("/de/"):
                 license_url_candidate = license_url_candidate[: -len("de/")]
             for valid_license_url in Constants.VALID_LICENSE_URLS:

--- a/converter/util/test_license_mapper.py
+++ b/converter/util/test_license_mapper.py
@@ -37,6 +37,7 @@ class TestLicenseMapper:
             # ToDo: Apache / BSD / GNU GPL licenses can't be mapped at the moment
             ("https://www.gnu.org/licenses/gpl-3.0", None),
             ("https://opensource.org/licenses/MIT", None),
+            ("http://creativecommons.org/licenses/by/3.0/de", Constants.LICENSE_CC_BY_30),
         ],
     )
     def test_get_license_url(self, test_input, expected_result):


### PR DESCRIPTION
- `oersi_spider` v0.0.9
- feat: lifecycle fields for URI identifiers (GND / ORCID / ROR / Wikidata)
- fix: small update to the LicenseMapper utility