### PR TITLE
OERSI updates (v0.1.1+)

### DIFF
--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -393,7 +393,7 @@ class EduSharing:
                 date = person["date"] if "date" in person else None
                 id_gnd: str = person["id_gnd"] if "id_gnd" in person else ""
                 id_orcid: str = person["id_orcid"] if "id_orcid" in person else ""
-                id_ror: str = person["id_ror"] if "id_ror"  in person else ""
+                id_ror: str = person["id_ror"] if "id_ror" in person else ""
                 id_wikidata: str = person["id_wikidata"] if "id_wikidata" in person else ""
                 vcard = vobject.vCard()
                 vcard.add("n").value = vobject.vcard.Name(
@@ -423,14 +423,20 @@ class EduSharing:
                     # fix a bug of split org values
                     vcard.org.behavior = VCardBehavior.defaultBehavior
                     vcard.org.value = organization
-                vcard.add("url").value = url
+                if url:
+                    vcard.add("url")
+                    vcard.url.value = url
                 if email:
                     vcard.add("EMAIL;TYPE=PREF,INTERNET").value = email
                 if mapping in spaces:
                     # checking if a vcard already exists for this role: if so, extend the list
-                    spaces[mapping].append(vcard.serialize())
+                    spaces[mapping].append(vcard.serialize(lineLength=10000))
+                    # default of "lineLength" is 75, which is too short for longer URLs. We're intentionally setting an
+                    # absurdly long lineLength, so we don't run into the problem where vCARD attributes like 'url' would
+                    # get split up with a '\r\n '-string inbetween, which would cause broken URLs in the final vCard
+                    # string and therefore broken links in the edu-sharing front-end
                 else:
-                    spaces[mapping] = [vcard.serialize()]
+                    spaces[mapping] = [vcard.serialize(lineLength=10000)]
 
         valuespaceMapping = {
             "accessibilitySummary": "ccm:accessibilitySummary",

--- a/converter/items.py
+++ b/converter/items.py
@@ -66,8 +66,8 @@ class LomLifecycleItem(Item):
     - 'ccm:lifecyclecontributer_publisher'              ('role'-value = 'publisher')
     - 'ccm:lifecyclecontributer_author'                 ('role'-value = 'author')
     - 'ccm:lifecyclecontributer_editor'                 ('role'-value = 'editor')
-    - 'ccm:lifecyclecontributer_metadata_creator'       ('role'-value = 'metadata_creator')
-    - 'ccm:lifecyclecontributer_metadata_provider'      ('role'-value = 'metadata_provider')
+    - 'ccm:metadatacontributer_creator'                 ('role'-value = 'metadata_creator')
+    - 'ccm:metadatacontributer_provider'                ('role'-value = 'metadata_provider')
     - 'ccm:lifecyclecontributer_unknown'                ('role'-value = 'unknown')
 
     The role 'unknown' is used for contributors in an unknown capacity ("Mitarbeiter").

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ certifi==2022.12.7
 urllib3~=1.26.09
 playwright==1.30.0
 pyOpenSSL==22.1.0
+black==23.3.0


### PR DESCRIPTION
This PR includes features & fixes for OERSI spider. Some highlights (please check the individual commit messages for details):

- `sourceOrganization`-fallback (for metadata providers which don't use the AMB `affiliation`-field)
- vCARD fixes & features:
    - fix/feat: individual vCARDs for `affiliation`-items
    - fix: vCARD `url`-attributes would get split up at (seemingly arbitrary) places within a long string
        - increased the `lineLength`-parameter from its default value (75) to 10.000, so we don't face the same problem in the future for other vCARD attributes
 - 2 new metadata providers within OERSI
    - "langSci Press" (202 items expected)
    - "OEPMS" (75 items expected)
 - fixes for the `getHash`-method
 - performance improvements:
    - by making the "should this item be updated?"-check earlier (before yielding a `scrapy.Request`), future crawling processes will be more efficient and spend less time waiting for the Scrapy Scheduler
    - additionally: by shuffling the list of URLs before yielding them as `scrapy.Request`s, we're trying to distribute the load between domains (which in turn should reduce the delays introduced by Scrapy's Autothrottle)