### PR TITLE
feat: Lehrer-Online - optional '.env'-setting to choose which items should be crawled

### DIFF
--- a/converter/.env.example
+++ b/converter/.env.example
@@ -77,3 +77,9 @@ YOUTUBE_API_KEY=""
 # <date_of_your_last_crawl>. Use this setting to improve the crawling speed of periodic crawls.
 # SERLO_INSTANCE="de"
 # Available Serlo "instance" values (as of 2023-08-02): "de" | "en" | "es" | "fr" | "hi" | "ta"
+
+# --- lehreronline_spider Settings
+#LO_SKIP_PORTAL="pubertaet;hwm"  # ignore both "Themenportale" at the same time (crawls ONLY Lehrer-Online)
+# skip individual "Themenportale" (offerings of cooperation partners) during a crawl by setting one of these values:
+# "hwm": skip all URLs from handwerk-macht-schule.de
+# "pubertaet": skip all URLs from "Themenportal Pubertät"


### PR DESCRIPTION
This PR implements a feature-request from 2023-08-10 by Team4 (Romy):
- a (completely optional) `.env`-setting for `lehreronline_spider` which allows us to control which "Themenportale" should be skipped during a crawl
  - currently possible settings:
     - `"hwm"` ignores all URLs from handwerk-macht-schule.de
     - `"pubertaet"` ignores all URLs from "Themenportal Pubertät"
   - **default behavior**: crawl all URLs as they are delivered by the Lehrer-Online API
- docs: update `.env.example` with examples for new, strictly optional setting