### PR TITLE
2023-08-15 feature requests and OER Sommercamp 2023 updates

### DIFF
--- a/converter/.env.example
+++ b/converter/.env.example
@@ -71,6 +71,8 @@ YOUTUBE_API_KEY=""
 # SODIX_SPIDER_PASSWORD = "<your_SODIX_API_password>"
 # --- sodix_spider settings:
 # SODIX_SPIDER_OER_FILTER=True  # OPTIONAL setting for crawling ONLY OER-compatible materials
+# SODIX_SPIDER_START_AT_PAGE="5"  # in case you need to (restart) a crawl process at a specific API page
+# (Before using the above setting, please confirm with an API Client like Insomnia if the desired page actually exists!)
 
 # --- serlo_spider (v0.2.8+) settings:
 # SERLO_MODIFIED_AFTER="2023-07-01"  # Crawl only Serlo Materials which have been modified (by Serlo authors) after

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -31,7 +31,7 @@ class SerloSpider(scrapy.Spider, LomBase):
     # start_urls = ["https://de.serlo.org"]
     API_URL = "https://api.serlo.org/graphql"
     # for the API description, please check: https://lenabi.serlo.org/metadata-api
-    version = "0.2.9"  # last update: 2023-08-04
+    version = "0.2.9"  # last update: 2023-08-16
     custom_settings = {
         # Using Playwright because of Splash-issues with thumbnails+text for Serlo
         "WEB_TOOLS": WebEngine.Playwright
@@ -255,6 +255,13 @@ class SerloSpider(scrapy.Spider, LomBase):
         if identifier is not None and hash_str is not None:
             if not self.hasChanged(response, kwargs={"graphql_json": graphql_json}):
                 drop_item_flag = True
+            return drop_item_flag
+        if "serlo.org/community/" in response.url:
+            # As requested by Team4/management on 2023-08-11: items from Serlo's "Blog-Archiv"
+            # (https://de.serlo.org/community/111255/blog-archiv) should not be crawled.
+            # We can use the resolved URL in 'response.url' for this purpose (minus the language-specific subdomain)
+            logging.info(f"Dropping URL {response.url} due to team4 decision on 2023-08-11.")
+            drop_item_flag = True
             return drop_item_flag
 
     def parse(self, response, **kwargs):

--- a/converter/spiders/serlo_spider.py
+++ b/converter/spiders/serlo_spider.py
@@ -56,8 +56,7 @@ class SerloSpider(scrapy.Spider, LomBase):
         # Someone already practicing a profession; an industry partner, or professional development trainer.
         "student": "learner",
     }
-    # ToDo: refactor this crawler-specific mapping into a separate (and testable) helper utility asap
-    # this mapping table is a temporary workaround until a mapping-utility for KIM Schulfächer URLs has been implemented
+    # see: http://w3id.org/kim/schulfaecher/ (https://github.com/dini-ag-kim/schulfaecher)
     KIM_TO_OEH_DISCIPLINE_MAPPING = {
         "s1000": "20003",  # Alt-Griechisch
         "s1040": "46014",  # Astronomie
@@ -94,9 +93,9 @@ class SerloSpider(scrapy.Spider, LomBase):
         # "s1037": "",  # ToDo: "Polnisch" doesn't exist in our 'discipline'-vocab yet
         # "s1038": "",  # ToDo: "Portugiesisch" doesn't exist in our 'discipline'-vocab yet
         # "s1043": "",  # ToDo: "Psychologie" doesn't exist in our 'discipline'-vocab yet
-        "s1024": "520",  # Religionslehre (evangelisch) -> Religionslehre
-        "s1025": "520",  # Religionslehre (islamisch) -> Religionslehre
-        "s1026": "520",  # Religionslehre (katholisch) -> Religionslehre
+        "s1024": "520",  # Religionslehre (evangelisch) → Religionslehre
+        "s1025": "520",  # Religionslehre (islamisch) → Religionslehre
+        "s1026": "520",  # Religionslehre (katholisch) → Religionslehre
         "s1027": "20006",  # Russisch
         "s1028": "28010",  # Sachunterricht
         "s1029": "560",  # Sexualerziehung
@@ -105,8 +104,11 @@ class SerloSpider(scrapy.Spider, LomBase):
         "s1031": "600",  # Sport
         "s1032": "20008",  # Türkisch
         "s1033": "700",  # Wirtschaftskunde
-        "s1042": "48005",  # Gesellschaftswissenschaften -> Gesellschaftskunde
+        "s1042": "48005",  # Gesellschaftswissenschaften → Gesellschaftskunde
     }
+    # ToDo: refactor this crawler-specific mapping into a separate (and testable) helper utility asap
+    # (this mapping table is a temporary workaround until a mapping-utility for DINI AG KIM Schulfächer URLs
+    # has been implemented)
 
     def __init__(self, **kw):
         LomBase.__init__(self, **kw)

--- a/converter/spiders/tutory_spider.py
+++ b/converter/spiders/tutory_spider.py
@@ -18,7 +18,7 @@ class TutorySpider(CrawlSpider, LomBase, JSONBase):
     url = "https://www.tutory.de/"
     objectUrl = "https://www.tutory.de/bereitstellung/dokument/"
     baseUrl = "https://www.tutory.de/api/v1/share/"
-    version = "0.1.8"  # last update: 2023-08-17
+    version = "0.1.9"  # last update: 2023-08-18
     custom_settings = {
         # "AUTOTHROTTLE_ENABLED": True,
         "AUTOTHROTTLE_DEBUG": True,
@@ -200,7 +200,7 @@ class TutorySpider(CrawlSpider, LomBase, JSONBase):
         educontext_set: set[str] = set()
         if potential_classlevel_values and type(potential_classlevel_values) is list:
             potential_classlevel_values.sort()
-            two_digits_pattern = re.compile(r"\d{1,2}")
+            two_digits_pattern = re.compile(r"^\d{1,2}$")  # the whole string must be exactly between 1 and 2 digits
             classlevel_set: set[str] = set()
             classlevel_digits: set[int] = set()
             for potential_classlevel in potential_classlevel_values:
@@ -217,6 +217,7 @@ class TutorySpider(CrawlSpider, LomBase, JSONBase):
                     # typical values: "1-ausbildungsjahr" / "2-ausbildungsjahr" / "3-ausbildungsjahr"
                     educontext_set.add("berufliche_bildung")
                 if "e-1" in potential_classlevel or "e-2" in potential_classlevel:
+                    educontext_set.add("sekundarstufe_1")
                     educontext_set.add("sekundarstufe_2")
             if classlevel_set and len(classlevel_set) > 0:
                 classlevels_sorted: list[str] = list(classlevel_set)

--- a/converter/spiders/zum_deutschlernen_spider.py
+++ b/converter/spiders/zum_deutschlernen_spider.py
@@ -22,7 +22,7 @@ class ZUMDeutschLernenSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_deutschlernen_spider"
     friendlyName = "ZUM-Deutsch-Lernen"
     url = "https://deutsch-lernen.zum.de/"
-    version = "0.1.4"  # last update: 2023-08-11
+    version = "0.1.5"  # last update: 2023-08-29
     license = Constants.LICENSE_CC_BY_40
     custom_settings = {"WEB_TOOLS": WebEngine.Playwright, "AUTOTHROTTLE_ENABLED": True, "AUTOTHROTTLE_DEBUG": True}
 

--- a/converter/spiders/zum_klexikon_spider.py
+++ b/converter/spiders/zum_klexikon_spider.py
@@ -23,7 +23,7 @@ class ZUMKlexikonSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_klexikon_spider"
     friendlyName = "ZUM-Klexikon"
     url = "https://klexikon.zum.de/"
-    version = "0.1.6"  # last update: 2023-08-11
+    version = "0.1.7"  # last update: 2023-08-29
     license = Constants.LICENSE_CC_BY_SA_40
     custom_settings = {"WEB_TOOLS": WebEngine.Playwright, "AUTOTHROTTLE_ENABLED": True, "AUTOTHROTTLE_DEBUG": True}
 

--- a/converter/spiders/zum_spider.py
+++ b/converter/spiders/zum_spider.py
@@ -13,7 +13,7 @@ class ZUMSpider(MediaWikiBase, scrapy.Spider):
     name = "zum_spider"
     friendlyName = "ZUM-Unterrichten"
     url = "https://unterrichten.zum.de/"
-    version = "0.1.4"  # last update: 2023-08-11
+    version = "0.1.5"  # last update: 2023-08-29
     license = Constants.LICENSE_CC_BY_SA_40
     custom_settings = {"WEB_TOOLS": WebEngine.Playwright, "AUTOTHROTTLE_ENABLED": True, "AUTOTHROTTLE_DEBUG": True}
 


### PR DESCRIPTION
This PR includes fixes and feature requests (by Team4/Romy) from 2023-08-15:
- `serlo_spider` v0.3.1:
  - feat: skip "Blog Archiv"-URLs
  - feat: KIM `schulfaecher` to OEH `discipline` mapping
  - feat: license edge case handling
  - feat: more precise `new_lrt`-vocab integration
    - during the Sommercamp 2023 Kulla and Romy discussed and implemented a (Serlo-internal) mapping from their content types to our `new_lrt`-vocab
      - (the `new_lrt`-values are provided within the `learningResourceType`-field of the Serlo API)
      - the crawler version v0.3.1 reflects these more precise values and only uses the older / broader `learningResourceType` (LRT) as a fallback from now on
- `MediaWikiBase` - MediaWiki crawlers (ZUM):
  - during the Sommercamp 2023 the experts from idea-sketch mentioned that URLs are (internally) encoded with underscores (`_`) instead of URL-encoded whitespaces
  - change: MediaWiki URLs are built by using underscores from now on 
    - version-bumped all crawlers to force a metadata refresh upon the next crawl
  - feat: `base.fulltext` no longer uses the `html2text`-package, but `trafilatura`s fulltext extraction instead
- `RSSBase` - RSS-based crawlers:
  - hard-coded values for `price` and `conditionsOfAccess`
- `sodix_spider`:
  - feat: optional `.env`-Setting to start crawler at a specific API page
- `tutory_spider` v0.1.5 - v0.1.9:
  - fix: `hasChanged`-check in `parse()`-method
  - perf: disable Scrapy Autothrottle (slow API response times would delay crawler requests to >= 21s)
  - workaround: `metaValues.subject` mapping
  - feat: `trafilatura`-fallback for additional `description`-metadata
  - perf: reduce amount of HTTP Requests to Tutory
    - only uses Playwright for website-screenshot in case that `thumbnail` url is missing
  - feat: `metaValues.classLevel` mapping to `educationalContext`