### PR TITLE
optimize SODIX program flow, increase crawler performance and reliability

### DIFF
--- a/converter/spiders/sodix_spider.py
+++ b/converter/spiders/sodix_spider.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 from typing import Iterator
@@ -10,6 +11,7 @@ from converter.items import *
 from .base_classes import JSONBase
 from .base_classes import LomBase
 from .. import env
+from ..es_connector import EduSharing
 from ..items import LomLifecycleItemloader
 from ..util.license_mapper import LicenseMapper
 
@@ -21,7 +23,7 @@ def extract_eaf_codes_to_set(eaf_code_list: list[str]) -> set:
     temporary_set = set()
     for eaf_code in eaf_code_list:
         if eaf_code:
-            # while this might be (theoretically) unnecessary, we're make sure to never grab empty strings
+            # while this might be (theoretically) unnecessary, we're making sure to never grab empty strings
             temporary_set.add(eaf_code)
     return temporary_set
 
@@ -40,7 +42,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
     name = "sodix_spider"
     friendlyName = "Sodix"
     url = "https://sodix.de/"
-    version = "0.3.0"  # last update: 2023-07-13
+    version = "0.3.0"  # last update: 2023-09-08
     apiUrl = "https://api.sodix.de/gql/graphql"
     page_size = 2500
     custom_settings = {
@@ -52,7 +54,13 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
     # control the modes either
     # - via spider arguments: "scrapy crawl sodix_spider -a oer_filter=true"
     # - or by setting SODIX_SPIDER_OER_FILTER=True in your .env file
-    NOT_OER_THROWAWAY_COUNTER = 0  # counts the amount of skipped items, in case that the OER-Filter is enabled
+    COUNTER_ITEM_IS_NOT_OER = 0  # counts the amount of skipped items, in case that the OER-Filter is enabled
+    COUNTER_ITEMS_IN_SODIX_API = 0  # counts the amount of extracted items from all API responses
+    COUNTER_ITEMS_TO_BE_CRAWLED = 0  # counts the amount of to-be-crawled items (new or to be updated items)
+    COUNTER_ITEMS_TO_BE_SKIPPED = 0  # counts the amount of items to be skipped (same version exists already)
+    SODIX_ITEMS: list[dict] = list()  # the crawler will collect all SODIX items from the API first before iterating
+    # over them. (This memory-intensive workaround is necessary because it was observed that index positions of items in
+    # the SODIX API change while the crawler is still iterating over the API pages.)
 
     MAPPING_LRT = {
         "APP": "application",
@@ -133,22 +141,61 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             self.OER_FILTER = True
         LomBase.__init__(self, **kwargs)
 
-    def mapResponse(self, response):
-        r = LomBase.mapResponse(self, response, fetchData=False)
-        r.replace_value("text", "")
-        r.replace_value("html", "")
-        r.replace_value("url", response.meta["item"].get("media").get("url"))
+    def close(self, reason):
+        """Print a quick overview (of different item counts) to the log when the crawler is shutting down."""
+        logging.info(
+            f"SODIX crawler (close reason: {reason}) summary:\n"
+            f"SODIX items counted during API Pagination: {self.COUNTER_ITEMS_IN_SODIX_API} .\n"
+            f"SODIX items to be crawled: {self.COUNTER_ITEMS_TO_BE_CRAWLED} .\n"
+            f"SODIX items to be skipped (item exists already / no update necessary) in total: "
+            f"{self.COUNTER_ITEMS_TO_BE_SKIPPED} .\n"
+            f"SODIX items to be skipped due to OER-Filter (sub-amount): {self.COUNTER_ITEM_IS_NOT_OER} .\n"
+        )
+
+    def mapResponse(self, response=None, **kwargs):
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"mapResponse(): Could not access SODIX item.")
+            raise ke
+        r = ResponseItemLoader()
+        r.replace_value("text", "")  # ToDo: this might be obsolete
+        r.replace_value("html", "")  # ToDo: this might be obsolete
+        r.replace_value("url", sodix_item["media"]["url"])
         return r
 
-    def getId(self, response):
-        return response.meta["item"].get("id")
+    def getId(self, response=None, **kwargs) -> str:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getId(): Could not access SODIX item.")
+            raise ke
+        return sodix_item["id"]
 
-    def getHash(self, response):
-        return f"{response.meta['item'].get('updated')}v{self.version}"
+    def getHash(self, response=None, **kwargs) -> str:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getHash(): Could not access SODIX item.")
+            raise ke
+        return f"{sodix_item['updated']}v{self.version}"
 
-    def getUri(self, response=None) -> str:
+    def getUUID(self, response=None, **kwargs) -> str:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getUUID(): Could not access SODIX item.")
+            raise ke
+        return EduSharing.build_uuid(self.getUri(response, sodix_item=sodix_item))
+
+    def getUri(self, response=None, **kwargs) -> str:
         # or media.originalUrl?
-        return self.get("media.url", json=response.meta["item"])
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getUri(): Could not access SODIX item.")
+            raise ke
+        return self.get("media.url", json=sodix_item)
 
     def start_request(self, page=0):
         access_token = requests.post(
@@ -162,13 +209,14 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         if self.OER_FILTER is True:
             recordstatus_parameter = ", recordStatus: ACTIVATED"
             # by using the recordStatus parameter during the GraphQL query, only a subset of available items is returned
-            # by the Sodix API: OER-only items carry the recordStatus: ACTIVATED
+            # by the Sodix API: Items which were marked/selected by the customer for export (in the (log-in restricted)
+            # SODIX web-interface) carry the 'recordStatus: ACTIVATED' property.
         else:
             recordstatus_parameter = ""
             # if OER-Filter is off (default), the GraphQL query will return all items (including non-OER materials)
         return scrapy.Request(
             url=self.apiUrl,
-            callback=self.parse_request,
+            callback=self.parse_api_page,
             body=json.dumps(
                 {
                     "query": f"""{{
@@ -281,7 +329,36 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         else:
             yield self.start_request()
 
-    def parse_request(self, response):
+    def hasChanged(self, response=None, **kwargs) -> bool:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+            identifier: str = self.getId(response, sodix_item=sodix_item)
+            hash_str: str = self.getHash(response, sodix_item=sodix_item)
+            uuid_str: str = self.getUUID(response, sodix_item=sodix_item)
+        except KeyError as ke:
+            logging.error(f"hasChanged(): Could not retrieve SODIX item.")
+            raise ke
+        if self.forceUpdate:
+            return True
+        if self.uuid:
+            if uuid_str == self.uuid:
+                logging.info(f"matching requested id: {self.uuid}")
+                return True
+            return False
+        if self.remoteId:
+            if identifier == self.remoteId:
+                logging.info(f"matching requested id: {self.remoteId}")
+                return True
+            return False
+        db = EduSharing().find_item(identifier, self)
+        changed = db is None or db[1] != hash_str
+        if not changed:
+            logging.info(f"Item {identifier} (uuid: {db[0]}) has not changed")
+            self.COUNTER_ITEMS_TO_BE_SKIPPED += 1
+        return changed
+
+    def parse_api_page(self, response):
+        """Parse the SODIX API response and paginate to the next API page if there were any results."""
         results = json.loads(response.body)
         if results:
             metadata_items: dict = results["data"]["findAllMetadata"]
@@ -289,57 +366,110 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             #     return
             if metadata_items:
                 # lists and dictionaries only become True if they have >0 entries, empty lists are considered False
-                for item in metadata_items:
-                    response_copy = response.copy()
-                    response_copy.meta["item"] = item
+                for sodix_item in metadata_items:
+                    self.COUNTER_ITEMS_IN_SODIX_API += 1
+                    sodix_item_copy = copy.deepcopy(sodix_item)
+                    # ToDo: this deepcopy might not be necessary after further program flow optimizations
                     if self.OER_FILTER is True or env.get_bool("SODIX_SPIDER_OER_FILTER", default=False):
                         # Since DropItem exceptions can only be raised from within the pipeline, the filtering of items
                         # that aren't strictly OER-licenses needs to happen here.
                         #  - controlling the OER-Filter via spider arguments is useful for debugging, but we also need
                         #   an easy way to control the spider via the .env file (while running it as a Docker container)
-                        if self.license_is_oer(response_copy) is False:
-                            self.NOT_OER_THROWAWAY_COUNTER += 1
+                        if self.license_is_oer(sodix_item_copy) is False:
+                            self.COUNTER_ITEM_IS_NOT_OER += 1
+                            self.COUNTER_ITEMS_TO_BE_SKIPPED += 1
                             self.logger.info(
                                 f"Item dropped due to OER-incompatibility. \n"
                                 f"Total amount of items dropped so far: "
-                                f"{self.NOT_OER_THROWAWAY_COUNTER}"
+                                f"{self.COUNTER_ITEM_IS_NOT_OER}"
                             )
                             continue
-                    if self.hasChanged(response_copy):
-                        yield self.handle_entry(response_copy)
+                    if self.hasChanged(response, sodix_item=sodix_item_copy):
+                        # Sommercamp 2023 observation: handle_entry needs to be called AFTER the complete item list has
+                        # been extracted, otherwise the items' index positions change while we're still iterating
+                        # through the API.
+                        self.SODIX_ITEMS.append(sodix_item_copy)
                 # ToDo: links to binary files (.jpeg) cause errors while building the BaseItem, we might have to filter
                 #  specific media types / URLs
                 yield self.start_request(response.meta["page"] + 1)
+            else:
+                if "errors" in results:
+                    error_dict: dict = results["errors"]
+                    try:
+                        error_message: str = error_dict["message"]
+                        logging.error(
+                            f"API Pagination: The SODIX API returned the following error-message while requesting page "
+                            f"{response.meta['page']} :\n{error_message}"
+                        )
+                    except KeyError:
+                        logging.error(
+                            f"API Pagination: The SODIX API returned the following error while requesting page "
+                            f"{response.meta['page']} :\n{error_dict}"
+                        )
+                else:
+                    # once we've reached the last API page, the 'findAllMetadata'-list will be empty, which is our
+                    # signal to start the actual parsing of individual items
+                    logging.info(
+                        f"API Pagination: Reached the last API page {response.meta['page']}. "
+                        f"Beginning crawling of {len(self.SODIX_ITEMS)} SODIX items..."
+                    )
+                    yield from self.handle_extracted_sodix_items()
 
-    def handle_entry(self, response):
-        return self.parse(response=response)
+    def handle_extracted_sodix_items(self):
+        """Checks if any items were collected from the SODIX API and yield the individual objects to be handled."""
+        if self.SODIX_ITEMS:
+            # if the crawler collected any items from the API, we're popping them 1-by-1 to reduce the initial memory
+            # footprint of the crawler
+            while self.SODIX_ITEMS:
+                self.COUNTER_ITEMS_TO_BE_CRAWLED += 1
+                next_item: dict = self.SODIX_ITEMS.pop()
+                yield self.handle_entry(next_item)
+            # ToDo: if we don't notice any side-effects of the above method, delete the below for-loop in v0.3.1+
+            # for sodix_item in self.SODIX_ITEMS:
+            #     self.COUNTER_ITEMS_TO_BE_CRAWLED += 1
+            #     yield self.handle_entry(sodix_item)
+        else:
+            logging.info(
+                f"The amount of extracted (and to be crawled) SODIX items is: {len(self.SODIX_ITEMS)}. "
+                f"Stopping crawl-process..."
+            )
 
-    def getBase(self, response) -> BaseItemLoader:
-        base = LomBase.getBase(self, response)
+    def handle_entry(self, sodix_item: dict):
+        return self.parse(cb_kwargs={"sodix_item": sodix_item})
+
+    def getBase(self, response=None, **kwargs) -> BaseItemLoader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getBase(): Could not access SODIX item.")
+            raise ke
+        base = BaseItemLoader()
+        base.add_value("sourceId", self.getId(response, sodix_item=sodix_item))
+        base.add_value("hash", self.getHash(response, sodix_item=sodix_item))
         # thumbnail-priority from different fields:
         # 1) media.thumbDetails (480x360) 2) media.thumbPreview (256x256) 3) source.imageUrl (480x360)
-        media_thumb_details = self.get("media.thumbDetails", json=response.meta["item"])
-        media_thumb_preview = self.get("media.thumbPreview", json=response.meta["item"])
-        source_image_url = self.get("source.imageUrl", json=response.meta["item"])
+        media_thumb_details = self.get("media.thumbDetails", json=sodix_item)
+        media_thumb_preview = self.get("media.thumbPreview", json=sodix_item)
+        source_image_url = self.get("source.imageUrl", json=sodix_item)
         if media_thumb_details:
             base.replace_value("thumbnail", media_thumb_details)
         elif media_thumb_preview:
             base.replace_value("thumbnail", media_thumb_preview)
         elif source_image_url:
             base.replace_value("thumbnail", source_image_url)
-        base.add_value("status", self.get("recordStatus", json=response.meta["item"]))
-        last_modified = self.get("updated", json=response.meta["item"])
+        base.add_value("status", self.get("recordStatus", json=sodix_item))
+        last_modified = self.get("updated", json=sodix_item)
         if last_modified:
             base.add_value("lastModified", last_modified)
-        source_id: str = self.get("source.id", json=response.meta["item"])
+        source_id: str = self.get("source.id", json=sodix_item)
         # ToDo: the crawler can't write description text to subfolder names yet
         #  'source.name' or 'source.description' could be used here to make the subfolders more human-readable
         if source_id:
             base.add_value("origin", source_id)
-        self.extract_and_save_eaf_codes_to_custom_field(base, response)
+        self.extract_and_save_eaf_codes_to_custom_field(base, sodix_item=sodix_item)
         return base
 
-    def extract_and_save_eaf_codes_to_custom_field(self, base: BaseItemLoader, response):
+    def extract_and_save_eaf_codes_to_custom_field(self, base: BaseItemLoader, sodix_item: dict):
         """
         Extracts eafCodes as a String from two Sodix API fields ('eafCode', 'competencies.id') and saves them to
         'base.custom' as a dictionary.
@@ -348,12 +478,12 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         """
         eaf_code_subjects = set()
         eaf_code_competencies = set()
-        eaf_code_subjects_list = self.get("eafCode", json=response.meta["item"])
+        eaf_code_subjects_list = self.get("eafCode", json=sodix_item)
         # Extracting eafCodes from 'subject.id':
         if eaf_code_subjects_list:
             eaf_code_subjects: set = extract_eaf_codes_to_set(eaf_code_subjects_list)
             # attention: eafCodes from Sodix field 'eafCode' and 'subject.id' carry the same information
-        eaf_code_competencies_list: list[dict] = self.get("competencies", json=response.meta["item"])
+        eaf_code_competencies_list: list[dict] = self.get("competencies", json=sodix_item)
         # eafCodes from Sodix field 'competencies.id' are not listed within the 'eafCode' field, therefore we're
         # gathering them separately and merge them with the other collected eafCodes if necessary
         if eaf_code_competencies_list:
@@ -379,12 +509,17 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                 eaf_code_competencies_list.sort()
                 base.add_value("custom", {"ccm:taxonentry": eaf_code_competencies_list})
 
-    def get_lom_lifecycle_author(self, response=None) -> LomLifecycleItemloader | None:
-        lifecycle = LomBase.getLOMLifecycle(response)
+    def get_lom_lifecycle_author(self, response=None, **kwargs) -> LomLifecycleItemloader | None:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"get_lom_lifecycle_author(): Could not access SODIX item.")
+            raise ke
+        lifecycle = LomLifecycleItemloader()
         # the Sodix 'author'-field returns a wild mix of agencies, persons, usernames and project-names
         # therfore all author-strings from Sodix are treated as "organization"-values
-        author = self.get("author", json=response.meta["item"])
-        author_website = self.get("authorWebsite", json=response.meta["item"])
+        author = self.get("author", json=sodix_item)
+        author_website = self.get("authorWebsite", json=sodix_item)
         if author and author_website:
             # edge-case: Some Sodix Items can have a "authorWebsite", but no valid "author"-value (e.g. null).
             # saving only the authorWebsite would lead to an empty author-symbol in the edu-sharing workspace view,
@@ -396,9 +531,14 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         else:
             return None
 
-    def get_lom_lifecycle_publisher(self, response=None) -> Iterator[LomLifecycleItemloader]:
-        lifecycle = LomBase.getLOMLifecycle(response)
-        publishers: list[dict] = self.get("publishers", json=response.meta["item"])
+    def get_lom_lifecycle_publisher(self, response=None, **kwargs) -> Iterator[LomLifecycleItemloader]:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"get_lom_lifecycle_publisher(): Could not access SODIX item.")
+            raise ke
+        lifecycle = LomLifecycleItemloader()
+        publishers: list[dict] = self.get("publishers", json=sodix_item)
         # Sodix 'publishers'-field is a list of Publishers, therefore we need to iterate through them
         if publishers:
             for publisher in publishers:
@@ -416,9 +556,9 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                     publisher_url: str = publisher.get("officialWebsite")
                     if publisher_url:
                         lifecycle.add_value("url", publisher_url)
-            published_time = self.get("publishedTime", json=response.meta["item"])
-            creation_date = self.get("creationDate", json=response.meta["item"])
-            source: dict = self.get("source", json=response.meta["item"])
+            published_time = self.get("publishedTime", json=sodix_item)
+            creation_date = self.get("creationDate", json=sodix_item)
+            source: dict = self.get("source", json=sodix_item)
             if published_time:
                 # the 'publishedTime'-field is 95% null or empty, which is why several fallbacks are needed
                 lifecycle.add_value("date", published_time)
@@ -434,13 +574,18 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                         lifecycle.add_value("date", created_date)
             yield lifecycle
 
-    def get_lom_lifecycle_metadata_provider(self, response=None) -> LomLifecycleItemloader:
+    def get_lom_lifecycle_metadata_provider(self, response=None, **kwargs) -> LomLifecycleItemloader:
         """
         Collects metadata from Sodix 'source'-field with the purpose of saving it to edu-sharing's
         'ccm:metadatacontributer_provider'-field.
         """
-        lifecycle = LomBase.getLOMLifecycle(response)
-        source: dict = self.get("source", json=response.meta["item"])
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"get_lom_lifecycle_metadata_provider: Could not access SODIX item.")
+            raise ke
+        lifecycle = LomLifecycleItemloader()
+        source: dict = self.get("source", json=sodix_item)
         if source:
             lifecycle.add_value("role", "metadata_provider")
             # all 'source'-subfields are of Type: String
@@ -457,11 +602,16 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                 lifecycle.add_value("url", source.get("website"))
         return lifecycle
 
-    def getLOMGeneral(self, response) -> LomGeneralItemloader:
-        general = LomBase.getLOMGeneral(self, response)
-        general.replace_value("title", self.get("title", json=response.meta["item"]))
-        if "keywords" in response.meta["item"]:
-            keywords: list = self.get("keywords", json=response.meta["item"])
+    def getLOMGeneral(self, response=None, **kwargs) -> LomGeneralItemloader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getLomGeneral(): Could not access SODIX item.")
+            raise ke
+        general = LomGeneralItemloader()
+        general.replace_value("title", self.get("title", json=sodix_item))
+        if "keywords" in sodix_item:
+            keywords: list = self.get("keywords", json=sodix_item)
             keywords_cleaned_up: list = list()
             if keywords:
                 # making sure that we're not receiving an empty list
@@ -470,20 +620,20 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                         # we're only adding valid keywords, none of the empty (whitespace) strings
                         keywords_cleaned_up.append(individual_keyword)
                         general.add_value("keyword", individual_keyword)
-            subjects = self.get_subject_dictionary(response)
+            subjects = self.get_subject_dictionary(sodix_item=sodix_item)
             if subjects:
                 subject_names = list(subjects.values())
                 subject_names.sort()
                 keywords_cleaned_up.extend(subject_names)
                 general.replace_value("keyword", keywords_cleaned_up)
-        if "language" in response.meta["item"]:
-            languages: list = self.get("language", json=response.meta["item"])
+        if "language" in sodix_item:
+            languages: list = self.get("language", json=sodix_item)
             if languages and isinstance(languages, list):
                 # Sodix returns empty lists and 'null' occasionally
                 for language in languages:
                     general.add_value("language", language)
-        if "description" in response.meta["item"]:
-            description: str = self.get("description", json=response.meta["item"])
+        if "description" in sodix_item:
+            description: str = self.get("description", json=sodix_item)
             if description:
                 # Sodix sometimes returns the 'description'-field as null
                 general.add_value("description", description)
@@ -493,35 +643,40 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         # the Sodix field 'id' is an uuid without further explanation
         # If both are available, they're saved as a [String] to 'cclom:general_identifier' (this might be necessary to
         # identify duplicates later in edu-sharing)
-        sodix_identifier: str = self.get("identifier", json=response.meta["item"])
+        sodix_identifier: str = self.get("identifier", json=sodix_item)
         if sodix_identifier:
             general.add_value("identifier", sodix_identifier)
-        sodix_id: str = self.get("id", json=response.meta["item"])
+        sodix_id: str = self.get("id", json=sodix_item)
         if sodix_id:
             general.add_value("identifier", sodix_id)
         return general
 
-    def getLOMTechnical(self, response) -> LomTechnicalItemLoader:
-        technical = LomBase.getLOMTechnical(self, response)
-        technical.replace_value("format", self.get("media.dataType", json=response.meta["item"]))
-        technical.replace_value("location", self.getUri(response))
-        original = self.get("media.originalUrl", json=response.meta["item"])
-        if original and self.getUri(response) != original:
+    def getLOMTechnical(self, response=None, **kwargs) -> LomTechnicalItemLoader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getLomTechnical(): Could not access SODIX item.")
+            raise ke
+        technical = LomTechnicalItemLoader()
+        technical.replace_value("format", self.get("media.dataType", json=sodix_item))
+        technical.replace_value("location", self.getUri(response, sodix_item=sodix_item))
+        original = self.get("media.originalUrl", json=sodix_item)
+        if original and self.getUri(response, sodix_item=sodix_item) != original:
             technical.add_value("location", original)
-        duration: str = self.get("media.duration", json=response.meta["item"])
+        duration: str = self.get("media.duration", json=sodix_item)
         if duration and duration != 0:
             # the API response contains "null"-values, we're making sure to only add valid duration values to our item
             technical.add_value("duration", duration)
-        technical.add_value("size", self.get("media.size", json=response.meta["item"]))
+        technical.add_value("size", self.get("media.size", json=sodix_item))
         return technical
 
-    def license_is_oer(self, response) -> bool:
+    def license_is_oer(self, sodix_item: dict) -> bool:
         """
         Checks if the Item is licensed under an OER-compatible license.
         Returns True if license is OER-compatible. (CC-BY/CC-BY-SA/CC0/PublicDomain)
         Otherwise returns False.
         """
-        license_name: str = self.get("license.name", json=response.meta["item"])
+        license_name: str = self.get("license.name", json=sodix_item)
         if license_name:
             if license_name in self.MAPPING_LICENSE_NAMES:
                 license_internal_mapped = self.MAPPING_LICENSE_NAMES.get(license_name)
@@ -538,13 +693,18 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                     Constants.LICENSE_PDM,
                 ]
 
-    def getLicense(self, response) -> LicenseItemLoader:
-        license_loader = LomBase.getLicense(self, response)
+    def getLicense(self, response=None, **kwargs) -> LicenseItemLoader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getLicense(): Could not access SODIX item.")
+            raise ke
+        license_loader = LicenseItemLoader()
 
-        author: str = self.get("author", json=response.meta["item"])
+        author: str = self.get("author", json=sodix_item)
         if author:
             license_loader.add_value("author", author)
-        license_description: str = self.get("license.text", json=response.meta["item"])
+        license_description: str = self.get("license.text", json=sodix_item)
         additional_license_information: str = self.get("additionalLicenseInformation")
         # the Sodix field 'additionalLicenseInformation' is empty 95% of the time, but sometimes it might serve as a
         # fallback for the license description
@@ -552,7 +712,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             license_loader.add_value("description", license_description)
         elif additional_license_information:
             license_loader.add_value("description", additional_license_information)
-        license_name: str = self.get("license.name", json=response.meta["item"])
+        license_name: str = self.get("license.name", json=sodix_item)
         if license_name:
             if license_name in self.MAPPING_LICENSE_NAMES:
                 license_name_mapped = self.MAPPING_LICENSE_NAMES.get(license_name)
@@ -572,7 +732,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                         # we're carrying over the custom description, just in case
                         license_loader.replace_value("description", license_name)
 
-        license_url_raw: str = self.get("license.url", json=response.meta["item"])
+        license_url_raw: str = self.get("license.url", json=sodix_item)
         # possible license URL values returned by the Sodix API:
         # license_urls_sorted = ['https://creativecommons.org/licenses/by-nc-nd/2.0/de/',
         #                        'https://creativecommons.org/licenses/by-nc-nd/3.0/de/',
@@ -612,9 +772,14 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                 license_loader.replace_value("url", license_url_mapped)
         return license_loader
 
-    def getLOMEducational(self, response=None) -> LomEducationalItemLoader:
-        educational = LomBase.getLOMEducational(response)
-        class_level = self.get("classLevel", json=response.meta["item"])
+    def getLOMEducational(self, response=None, **kwargs) -> LomEducationalItemLoader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getLomEducational(): Could not access SODIX item.")
+            raise ke
+        educational = LomEducationalItemLoader()
+        class_level = self.get("classLevel", json=sodix_item)
         if class_level and len(class_level.split("-")) == 2:
             split = class_level.split("-")
             tar = LomAgeRangeItemLoader()
@@ -624,16 +789,16 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             educational.add_value("typicalAgeRange", tar.load_item())
         return educational
 
-    def get_subject_dictionary(self, response) -> dict[str, str] | None:
+    def get_subject_dictionary(self, sodix_item: dict) -> dict[str, str] | None:
         """
         Parses the Sodix API field 'subject' and returns a dictionary consisting of:
         Sodix 'subject.id' (= the eafCode of a "Schulfach") and its human-readable counterpart
         Sodix 'subject.name' as its value.
         """
         subject_dictionary = dict()
-        if "subject" in response.meta["item"] is not None:
+        if "subject" in sodix_item is not None:
             # the "subject"-field does not exist in every item returned by the sodix API
-            subjects_list: list = self.get("subject", json=response.meta["item"])
+            subjects_list: list = self.get("subject", json=sodix_item)
             if subjects_list:
                 # the "subject"-key might exist in the API, but still be of 'None'-value
                 for subject in subjects_list:
@@ -644,16 +809,22 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
             else:
                 return None
 
-    def getValuespaces(self, response) -> ValuespaceItemLoader:
+    def getValuespaces(self, response, **kwargs) -> ValuespaceItemLoader:
+        try:
+            sodix_item: dict = kwargs["sodix_item"]
+        except KeyError as ke:
+            logging.error(f"getValuespaces(): Could not access SODIX item.")
+            raise ke
+
         valuespaces = LomBase.getValuespaces(self, response)
-        subjects = self.get_subject_dictionary(response)
+        subjects = self.get_subject_dictionary(sodix_item=sodix_item)
         if subjects:
             subject_ids = list(subjects.keys())
             if subject_ids:
                 subject_ids.sort()
                 valuespaces.add_value("discipline", subject_ids)
-        educational_context_list = self.get("educationalLevels", json=response.meta["item"])
-        school_types_list = self.get("schoolTypes", json=response.meta["item"])
+        educational_context_list = self.get("educationalLevels", json=sodix_item)
+        school_types_list = self.get("schoolTypes", json=sodix_item)
         educational_context_set = set()
         if educational_context_list:
             # the Sodix field 'educationalLevels' is directly mappable to our 'educationalContext'
@@ -672,7 +843,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
         if educational_context_list:
             valuespaces.add_value("educationalContext", educational_context_list)
 
-        target_audience_list = self.get("targetAudience", json=response.meta["item"])
+        target_audience_list = self.get("targetAudience", json=sodix_item)
         # possible 'targetAudience'-values according to the SODIX API Docs: "teacher", "learner", "parent"
         if target_audience_list:
             for target_audience_item in target_audience_list:
@@ -680,7 +851,7 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                     target_audience_item = self.MAPPING_INTENDED_END_USER_ROLE.get(target_audience_item)
                 valuespaces.add_value("intendedEndUserRole", target_audience_item)
 
-        cost: str | None = self.get("cost", json=response.meta["item"])
+        cost: str | None = self.get("cost", json=sodix_item)
         if cost:
             cost = cost.lower()
             match cost:
@@ -696,8 +867,8 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                         f"Documentation if the possible range of values has changed in the meantime. "
                         f"(In this case: additional metadata values need to be mapped.)"
                     )
-        potential_lrts = self.get("learnResourceType", json=response.meta["item"])
-        # attention: Sodix calls their LRT "learnResourceType", not "learningResourceType"
+        potential_lrts = self.get("learnResourceType", json=sodix_item)
+        # attention: Sodix calls their LRT "learnResourceType", not "learningResourceType"!
         if potential_lrts:
             for potential_lrt in potential_lrts:
                 if potential_lrt in self.MAPPING_LRT:
@@ -705,49 +876,59 @@ class SodixSpider(scrapy.Spider, LomBase, JSONBase):
                 valuespaces.add_value("learningResourceType", potential_lrt)
         return valuespaces
 
-    def parse(self, response, **kwargs):
-        if LomBase.shouldImport(response) is False:
-            self.logger.debug(f"Skipping entry {str(self.getId(response))} because shouldImport() returned false")
+    def parse(self, response=None, **kwargs):
+        # The 'response'-object will always be of type None due to the way the crawler is currently designed. Since the
+        # crawler does not make any 'scrapy.Request's to the target websites (anymore), we could completely refactor all
+        # crawler methods to increase readability/maintainability of the crawler code.
+        try:
+            sodix_item: dict = kwargs["cb_kwargs"]["sodix_item"]
+        except KeyError:
+            logging.error(f"Cannot parse SODIX item from callback arguments. Aborting parse()-method.")
             return None
-        if self.getId(response) is not None and self.getHash(response) is not None:
-            if not self.hasChanged(response):
-                return None
 
-        base = self.getBase(response)
+        if LomBase.shouldImport(response) is False:
+            self.logger.debug(
+                f"Skipping entry {str(self.getId(response, sodix_item=sodix_item))} because shouldImport() returned "
+                f"false"
+            )
+            self.COUNTER_ITEMS_TO_BE_SKIPPED += 1
+            return None
+
+        base = self.getBase(response, sodix_item=sodix_item)
 
         lom = LomBaseItemloader()
-        general = self.getLOMGeneral(response)
+        general = self.getLOMGeneral(response, sodix_item=sodix_item)
 
         # "UNTERRICHTSBAUSTEIN"-Materials need to handled as aggregationLevel = 2 (according to LOM-DE)
-        potential_lrts = self.get("learnResourceType", json=response.meta["item"])
+        potential_lrts = self.get("learnResourceType", json=sodix_item)
         if potential_lrts:
             if "UNTERRICHTSBAUSTEIN" in potential_lrts:
                 general.add_value("aggregationLevel", 2)
-        technical = self.getLOMTechnical(response)
-        if self.get("author", json=response.meta["item"]):
-            lifecycle_author = self.get_lom_lifecycle_author(response)
+        technical = self.getLOMTechnical(response, sodix_item=sodix_item)
+        if self.get("author", json=sodix_item):
+            lifecycle_author = self.get_lom_lifecycle_author(response, sodix_item=sodix_item)
             if lifecycle_author:
                 lom.add_value("lifecycle", lifecycle_author.load_item())
-        if self.get("publishers", json=response.meta["item"]):
+        if self.get("publishers", json=sodix_item):
             # theoretically, there can be multiple publisher fields per item, but in reality this doesn't occur (yet).
-            lifecycle_iterator: Iterator[LomLifecycleItemloader] = self.get_lom_lifecycle_publisher(response)
+            lifecycle_iterator: Iterator[LomLifecycleItemloader] = self.get_lom_lifecycle_publisher(
+                response, sodix_item=sodix_item
+            )
             for lifecycle_publisher in lifecycle_iterator:
                 lom.add_value("lifecycle", lifecycle_publisher.load_item())
-        if self.get("source", json=response.meta["item"]):
-            lifecycle_metadata_provider = self.get_lom_lifecycle_metadata_provider(response)
+        if self.get("source", json=sodix_item):
+            lifecycle_metadata_provider = self.get_lom_lifecycle_metadata_provider(response, sodix_item=sodix_item)
             lom.add_value("lifecycle", lifecycle_metadata_provider.load_item())
-        educational = self.getLOMEducational(response)
-        classification = self.getLOMClassification(response)
+        educational = self.getLOMEducational(response, sodix_item=sodix_item)
 
         lom.add_value("general", general.load_item())
         lom.add_value("technical", technical.load_item())
         lom.add_value("educational", educational.load_item())
-        lom.add_value("classification", classification.load_item())
         base.add_value("lom", lom.load_item())
 
-        base.add_value("valuespaces", self.getValuespaces(response).load_item())
-        base.add_value("license", self.getLicense(response).load_item())
+        base.add_value("valuespaces", self.getValuespaces(response, sodix_item=sodix_item).load_item())
+        base.add_value("license", self.getLicense(response, sodix_item=sodix_item).load_item())
         base.add_value("permissions", self.getPermissions(response).load_item())
-        base.add_value("response", self.mapResponse(response).load_item())
+        base.add_value("response", self.mapResponse(response, sodix_item=sodix_item).load_item())
 
         return base.load_item()


### PR DESCRIPTION
This PR includes the following changes to `sodix_spider` to increase its performance & reliability during unfiltered crawls:
- **reworked** `sodix_spider` program flow to collect **all** items from the API first, then crawl the individual items after the API pagination is complete 
  - during the OER Sommercamp 2023 preparations it was observed that parts of the SODIX API results (~80k items in total) could switch positions in the result index while the crawler was still running and still paginating through the API
    - while this was never a problem for the Lisum crawler, this problematic API behaviour made it necessary to run the crawler more than once to collect all items from the API
  - the reworked program flow has the side-effect that all SODIX items **are kept in-memory** and will be `.pop()`ed one-by-one during item processing 
    - (RAM usage will be higher at the beginning of a crawl and should go down the more items have been processed by our `parse()`-method)
  - (please check the individual git commit messages for a more detailed explanation)
- feat: implemented a (basic) item counter to make future debugging easier
  - counts items collected from the API as well as items to be crawled / skipped / filtered and prints an overview when the `close()`-method of the crawler is called
- feat: fallbacks for `media.url` edge-cases when the SODIX API doesn't provide any URI for the (required) `media.url` field
  - fallback to `media.originalUrl` for these edge-cases
    - trying to process items with `null`ed `media.url`-fields would cause the crawler to drop the item and potentially crash the crawling-process