### PR TITLE
feat: attach whitelisted edu-sharing "source template" metadata properties to scraped items ("Quellen-Datensatz"-Template)

### DIFF
--- a/converter/.env.example
+++ b/converter/.env.example
@@ -2,19 +2,19 @@
 # Add a url for your log file. If not set, stdoutput will be used
 #LOG_FILE = "/var/log/scrapy.log"
 # Set the level for logs here. Supported values: "DEBUG", "INFO", "WARNING", "ERROR"
-LOG_LEVEL = "WARNING"
+LOG_LEVEL="WARNING"
 
 # --- Crawling-modes: control where crawled items should be stored/exported.
 # Available modes: 'edu-sharing', 'csv', 'json' or 'None'
-MODE = "csv"
+MODE="csv"
 # ------ CSV Export settings (Only used if MODE == "csv"!):
 # csv rows to export from dataset (comma seperated! field-names according to items.py!)
-CSV_ROWS = "lom.general.title,lom.general.description,lom.general.keyword,lom.technical.location,valuespaces.discipline,valuespaces.learningResourceType"
+CSV_ROWS="lom.general.title,lom.general.description,lom.general.keyword,lom.technical.location,valuespaces.discipline,valuespaces.learningResourceType"
 
 # --- 'Splash'-Integration settings for the local container,
 # for more information, see https://splash.readthedocs.io/en/stable/
-DISABLE_SPLASH = False
-SPLASH_URL = "http://localhost:8050"
+DISABLE_SPLASH=False
+SPLASH_URL="http://localhost:8050"
 
 # --- headless-browser settings for the local container:
 # PYPPETEER Integration settings, as needed for the local container (as used in kmap_spider.py)
@@ -24,9 +24,9 @@ PYPPETEER_WS_ENDPOINT="ws://localhost:3000"
 PLAYWRIGHT_WS_ENDPOINT="ws://localhost:3000"
 
 # --- Edu-Sharing instance that the crawlers should upload to
-EDU_SHARING_BASE_URL = "http://localhost:8080/edu-sharing/"
-EDU_SHARING_USERNAME = "admin"
-EDU_SHARING_PASSWORD = "admin"
+EDU_SHARING_BASE_URL="http://localhost:8080/edu-sharing/"
+EDU_SHARING_USERNAME="admin"
+EDU_SHARING_PASSWORD="admin"
 
 # Configure if permissions of edu-sharing nodes are handled by the crawler (default true)
 # You may want to set this to false if you don't want to apply permissions from crawlers or have a custom implementation in the repository
@@ -35,7 +35,20 @@ EDU_SHARING_PASSWORD = "admin"
 # EDU_SHARING_METADATASET=mds_oeh
 
 # If set to true, don't upload to (above mentioned) Edu-Sharing instance
-DRY_RUN = True
+DRY_RUN=True
+
+# --- edu-sharing Source Template Settings
+# Retrieve (whitelisted) metadata properties from an edu-sharing "source template" ("Quellen-Datensatz"-Template) and
+# attach those metadata properties to each item. (This feature is DISABLED by default. Possible values: True / False)
+# Before enabling this feature, make sure that:
+# - a "Quellen-Datensatz" exists for the <spider_name> within the specified edu-sharing repository
+#   (see: EDU_SHARING_BASE_URL setting above!)
+# - AND contains the "ccm:oeh_crawler_data_inherit" property !
+EDU_SHARING_SOURCE_TEMPLATE_ENABLED=False
+# Define a separate "source template"-repository for testing/debugging. This setting is useful if
+# the "Quellen-Datensatz" does not exist on the same edu-sharing repository as defined in EDU_SHARING_BASE_URL
+# (e.g., when the "Quellen-Datensatz"-Template is only available on Staging, but you want save the items on pre-Staging)
+#EDU_SHARING_SOURCE_TEMPLATE_BASE_URL="http://localhost:8080/edu-sharing/"
 
 # --- OERSI-specific settings (oersi_spider):
 # Only crawl a specific metadata provider from OERSI (separate multiple providers by semicolon!):

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -113,8 +113,6 @@ class EduSharing:
     enabled: bool
     _client_async = httpx.AsyncClient()
     _sem: Semaphore = asyncio.Semaphore(25)
-    source_template_properties: dict  # whitelisted crawler source metadata properties
-    # (from a "Quellen-Datensatz" / crawler source template) which should be attached to each processed item
 
     def __init__(self):
         cookie_threshold = env.get("EDU_SHARING_COOKIE_REBUILD_THRESHOLD", True)
@@ -366,10 +364,10 @@ class EduSharing:
         if "origin" in item:
             spaces["ccm:replicationsourceorigin"] = item["origin"]  # TODO currently not mapped in edu-sharing
 
-        if hasattr(spider, "EST_WHITELIST"):
+        if hasattr(spider, "edu_sharing_source_template_whitelist"):
             # check if there were whitelisted metadata properties in the edu-sharing source template
             # (= "Quellen-Datensatz"-Template) that need to be attached to all items
-            whitelisted_properties: dict = getattr(spider, "EST_WHITELIST")
+            whitelisted_properties: dict = getattr(spider, "edu_sharing_source_template_whitelist")
             if whitelisted_properties:
                 # if whitelisted properties exist, we re-use the 'custom' field in our data model (if possible).
                 # by inserting the whitelisted metadata properties early in the program flow, they should automatically

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -113,6 +113,8 @@ class EduSharing:
     enabled: bool
     _client_async = httpx.AsyncClient()
     _sem: Semaphore = asyncio.Semaphore(25)
+    source_template_properties: dict  # whitelisted crawler source metadata properties
+    # (from a "Quellen-Datensatz" / crawler source template) which should be attached to each processed item
 
     def __init__(self):
         cookie_threshold = env.get("EDU_SHARING_COOKIE_REBUILD_THRESHOLD", True)
@@ -364,6 +366,30 @@ class EduSharing:
         if "origin" in item:
             spaces["ccm:replicationsourceorigin"] = item["origin"]  # TODO currently not mapped in edu-sharing
 
+        if hasattr(spider, "EST_WHITELIST"):
+            # check if there were whitelisted metadata properties in the edu-sharing source template
+            # (= "Quellen-Datensatz"-Template) that need to be attached to all items
+            whitelisted_properties: dict = getattr(spider, "EST_WHITELIST")
+            if whitelisted_properties:
+                # if whitelisted properties exist, we re-use the 'custom' field in our data model (if possible).
+                # by inserting the whitelisted metadata properties early in the program flow, they should automatically
+                # be overwritten by the "real" metadata fields (if metadata was scraped for the specific field by the
+                # crawler)
+                if hasattr(item, "custom"):
+                    custom: dict = item["custom"]
+                    if custom:
+                        # if 'BaseItem.custom' already exists -> update the dict
+                        custom.update(whitelisted_properties)
+                        item["custom"] = custom
+                else:
+                    # otherwise create the 'BaseItem.custom'-field
+                    item["custom"] = whitelisted_properties
+
+        # map custom fields directly into the edu-sharing properties:
+        if "custom" in item:
+            for key in item["custom"]:
+                spaces[key] = item["custom"][key]
+
         self.map_license(spaces, item["license"])
         if "description" in item["lom"]["general"]:
             spaces["cclom:general_description"] = item["lom"]["general"]["description"]
@@ -485,11 +511,6 @@ class EduSharing:
                 spaces["ccm:educationaltypicalagerange_from"] = tar["fromRange"]
             if "toRange" in tar:
                 spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
-
-        # map custom fields directly into the edu-sharing properties
-        if "custom" in item:
-            for key in item["custom"]:
-                spaces[key] = item["custom"][key]
 
         # intendedEndUserRole = Field(output_processor=JoinMultivalues())
         # discipline = Field(output_processor=JoinMultivalues())

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -772,7 +772,7 @@ class EduSharingStorePipeline(EduSharing, BasicPipeline):
             est_helper: EduSharingSourceTemplateHelper = EduSharingSourceTemplateHelper(crawler_name=spider.name)
             whitelisted_properties: dict | None = est_helper.get_whitelisted_metadata_properties()
             if whitelisted_properties:
-                setattr(spider, "EST_WHITELIST", whitelisted_properties)
+                setattr(spider, "edu_sharing_source_template_whitelist", whitelisted_properties)
                 logging.debug(f"Edu-sharing source template retrieval was successful. "
                               f"The following metadata properties will be whitelisted for all items:\n"
                               f"{whitelisted_properties}")

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -39,6 +39,7 @@ from converter import env
 from converter.constants import *
 from converter.es_connector import EduSharing
 from converter.items import BaseItem
+from converter.util.edu_sharing_source_template_helper import EduSharingSourceTemplateHelper
 from converter.util.language_mapper import LanguageMapper
 from converter.web_tools import WebTools, WebEngine
 from valuespace_converter.app.valuespaces import Valuespaces
@@ -755,6 +756,31 @@ class EduSharingStorePipeline(EduSharing, BasicPipeline):
     def __init__(self):
         super().__init__()
         self.counter = 0
+
+    def open_spider(self, spider):
+        logging.debug("Entering EduSharingStorePipeline...\n"
+                      "Checking if 'crawler source template' ('Quellendatensatz-Template') should be used "
+                      "(see: 'EDU_SHARING_SOURCE_TEMPLATE_ENABLED' .env setting)...")
+        est_enabled: bool = env.get_bool("EDU_SHARING_SOURCE_TEMPLATE_ENABLED", allow_null=True, default=False)
+        # defaults to False for backwards-compatibility.
+        # (The EduSharingSourceTemplateHelper class is explicitly set to throw errors and abort a crawl if this setting
+        # is enabled! Activate this setting on a per-crawler basis!)
+        if est_enabled:
+            # "Quellendatensatz-Templates" might not be available on every edu-sharing instance. This feature is only
+            # active if explicitly set via the .env file. (This choice was made to avoid errors with
+            # old or unsupported crawlers.)
+            est_helper: EduSharingSourceTemplateHelper = EduSharingSourceTemplateHelper(crawler_name=spider.name)
+            whitelisted_properties: dict | None = est_helper.get_whitelisted_metadata_properties()
+            if whitelisted_properties:
+                setattr(spider, "EST_WHITELIST", whitelisted_properties)
+                logging.debug(f"Edu-sharing source template retrieval was successful. "
+                              f"The following metadata properties will be whitelisted for all items:\n"
+                              f"{whitelisted_properties}")
+            else:
+                logging.error(f"Edu-Sharing Source Template retrieval failed. "
+                              f"(Does a 'Quellendatensatz' exist in the edu-sharing repository for this spider?)")
+        else:
+            log.debug(f"Edu-Sharing Source Template feature is NOT ENABLED. Continuing EduSharingStorePipeline...")
 
     async def process_item(self, raw_item, spider):
         item = ItemAdapter(raw_item)

--- a/converter/util/edu_sharing_source_template_helper.py
+++ b/converter/util/edu_sharing_source_template_helper.py
@@ -1,0 +1,317 @@
+import logging
+from pprint import pp
+
+import requests
+
+from converter import env
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+class EduSharingSourceTemplateHelper:
+    """
+    Helper class for retrieving (whitelisted) metadata properties from an edu-sharing crawler "source template"
+    (= "Quellen-Datensatz"-Template) from a specified edu-sharing repository.
+    The retrieved metadata properties will later be used as a fallback for crawler items when a crawler couldn't
+    scrape a specific metadata property by itself.
+
+    This feature REQUIRES an API endpoint in the edu-sharing repository (available in v8.1 or higher)!
+    """
+
+    _edu_sharing_base_url: str = "https://localhost:8000/edu-sharing/"
+    _api_path: str = "rest/search/v1/queries/"
+    _repository: str = "-home-"
+    _meta_data_set: str = "mds_oeh"
+    _api_endpoint: str = "wlo_crawler_element"
+    _api_endpoint_params: str = "propertyFilter=-all-"
+    _url: str = (
+        f"{_edu_sharing_base_url}{_api_path}{_repository}"
+        f"/{_meta_data_set}"
+        f"/{_api_endpoint}?{_api_endpoint_params}"
+    )
+
+    _headers: dict = {
+        "accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    _crawler_name: str = None
+    _payload: dict = dict()
+
+    # ToDo:
+    #  - code cleanup (improve readability of logging messages)
+    #  - implement pytest test-scenarios
+
+    def __init__(self, crawler_name: str = None):
+        """
+        Initialize the 'source template'-helper class with the provided settings from the '.env'-file and prepare the
+        API queryy.
+
+        After initiating the EduSharingSourceTemplateHelper class,
+        call "get_whitelisted_metadata_properties()" on its instance.
+        Example:
+
+        >>> esth = EduSharingSourceTemplateHelper(crawler_name="zum_klexikon_spider")
+        >>> whitelisted_properties: dict = esth.get_whitelisted_metadata_properties()
+
+        :param crawler_name: the spider_name ('spider.friendlyName'), e.g. "zum_klexikon_spider"
+        """
+        if crawler_name:
+            self._set_crawler_name_for_payload(crawler_name=crawler_name)
+        self._initiate_from_dotenv()
+        self._build_payload()
+
+    def _initiate_from_dotenv(self):
+        edu_sharing_source_template_repository_from_dotenv: str = env.get(
+            key="EDU_SHARING_SOURCE_TEMPLATE_BASE_URL", allow_null=True, default=None
+        )
+        edu_sharing_base_url_from_dot_env: str = env.get(key="EDU_SHARING_BASE_URL", allow_null=True, default=None)
+        if edu_sharing_source_template_repository_from_dotenv:
+            # explicitly specify from which edu-sharing repository a "Quellen-Datensatz"-Template should be retrieved
+            # (e.g., if you're crawling against pre-Staging, but want to fetch the template from either Prod or Staging)
+            self._set_edu_sharing_url(edu_sharing_source_template_repository_from_dotenv)
+        elif edu_sharing_base_url_from_dot_env:
+            # fallback for convenience: if no repository was explicitly set in the .env, we assume that the crawler
+            # source template shall be fetched from the same edu-sharing repository that is used for storing the items
+            # (e.g., crawling against production)
+            self._set_edu_sharing_url(edu_sharing_base_url_from_dot_env)
+        else:
+            log.info(
+                f"Could not read '.env'-Setting 'EDU_SHARING_BASE_URL'. Please check your '.env'-file! "
+                f"(For additional help, see: oeh-search-etl/converter/.env.example )."
+            )
+            pass
+
+    def _set_edu_sharing_url(self, edu_sharing_source_template_repository: str):
+        self._edu_sharing_base_url = edu_sharing_source_template_repository
+        self._url = (
+            f"{self._edu_sharing_base_url}{self._api_path}"
+            f"{self._repository}/"
+            f"{self._meta_data_set}/"
+            f"{self._api_endpoint}?{self._api_endpoint_params}"
+        )
+
+    def _set_crawler_name_for_payload(self, crawler_name: str):
+        self._crawler_name = crawler_name
+
+    def _build_payload(self) -> dict | None:
+        """
+        Build JSON payload object. Class variable 'crawler_name' needs to be set beforehand.
+
+        :return: payload object as 'dict' or None.
+        """
+        if self._crawler_name:
+            payload: dict = {
+                "criteria": [
+                    {
+                        "property": "ccm:general_identifier",
+                        "values": [f"{self._crawler_name}"],
+                    }
+                ],
+            }
+            self._payload = payload
+            return payload
+        else:
+            log.error(
+                f"Cannot build query payload without valid crawler_name. Please make sure that you instantiate "
+                f"EduSharingTemplateHelper with a valid 'crawler_name'-parameter!"
+            )
+            return None
+
+    def _retrieve_whitelisted_metadata_properties(self) -> dict | None:
+        """
+        Query the edu-sharing repository for a crawler 'source dataset'-template (= "Quellen-Datensatz"-Template) and
+        return the whitelisted metadata properties as a dict.
+        If the response was invalid for whatever reason, return None.
+
+        :return: whitelisted metadata properties as dict or None.
+        """
+        response: requests.Response = requests.request("POST", url=self._url, json=self._payload, headers=self._headers)
+
+        status_code: int = response.status_code
+        if status_code == 200:
+            # ToDo: even if the crawler_name doesn't exist, the edu-sharing response will be HTTP-Status-Code 200:
+            #   - ALWAYS check validity of 'nodes' and 'pagination'! (-> 'nodes' is empty & 'pagination.count' == 0)
+            try:
+                result_dict = response.json()
+            except requests.exceptions.JSONDecodeError as jde:
+                log.error(f"The edu-sharing response could not be parsed as JSON. Response:\n" f"{response.text}")
+                raise jde
+
+            try:
+                pagination: dict = result_dict["pagination"]
+                pagination_total = pagination["total"]
+                pagination_count = pagination["count"]
+            except KeyError:
+                log.error(
+                    f"Missing 'pagination'-object in edu-sharing response. "
+                    f"Aborting EduSharingSourceTemplateHelper process..."
+                )
+                raise KeyError
+
+            if pagination_count and pagination_total and pagination_count == 1 and pagination_total == 1:
+                # this is our happy case:
+                # 'count' and 'total' should BOTH be 1 if there is a (valid) crawler source dataset
+                pass
+            else:
+                # unexpected API behavior -> abort here by returning None
+                log.error(
+                    f"The edu-sharing API returned an unexpected number of crawler 'source template' results:\n"
+                    f"Expected 'pagination.count': 1 (received: {pagination_count} ) // "
+                    f"expected 'pagination.total': 1 (received: {pagination_total} )"
+                )
+                if pagination_count == 0 and pagination_total == 0:
+                    log.error(
+                        f"Please make sure that a 'source template' ('Quellen-Datensatz'-template) for crawler "
+                        f"'{self._crawler_name}' exists within the specified edu-sharing repository "
+                        f"{self._edu_sharing_base_url} !"
+                    )
+                if pagination_count > 1 or pagination_total > 1:
+                    log.error(
+                        f"edu-sharing returned more than one 'crawler source template' for the specified "
+                        f"crawler '{self._crawler_name}'. "
+                    )
+                return None
+
+            nodes_list: list[dict] = result_dict["nodes"]
+            if nodes_list and isinstance(nodes_list, list) and len(nodes_list) == 1:
+                # 'nodes' should contain exactly 1 dict -> if more are returned, the API shows unexpected behaviour
+                nodes: dict = nodes_list[0]
+                nodes_properties: dict = nodes["properties"]
+                _whitelisted_properties: dict = dict()
+                _oeh_cdi: str = "ccm:oeh_crawler_data_inherit"
+                """The property 'ccm:oeh_crawler_data_inherit' contains all whitelisted property keys, but NOT their 
+                values!"""
+                try:
+                    if _oeh_cdi in nodes_properties:
+                        # checking if "ccm:oeh_crawler_data_inherit" is part of the API response
+                        # the whitelist-property should be available within 'nodes[0].properties' and might look like:
+                        # "ccm:oeh_crawler_data_inherit": [
+                        # 					"ccm:containsAdvertisement",
+                        # 					"ccm:oeh_quality_login",
+                        # 					"ccm:oeh_languageTarget",
+                        # 					"ccm:oeh_languageLevel"
+                        # 				]
+                        whitelist_keys: list[str] = nodes_properties[_oeh_cdi]
+                        log.info(f"'{_oeh_cdi}' contains the following properties: \n" f"{whitelist_keys}")
+                        if whitelist_keys and isinstance(whitelist_keys, list):
+                            for whitelist_key in whitelist_keys:
+                                # the values for each property need to be looked up separately
+                                whitelisted_property_value: list[str] = nodes_properties.get(whitelist_key)
+                                # ToDo: implement check for empty properties / strings?
+                                #  OR: trust that the edu-sharing API response is always valid?
+                                if whitelisted_property_value:
+                                    _whitelisted_properties.update({f"{whitelist_key}": whitelisted_property_value})
+                        else:
+                            log.error(
+                                f"Received unexpected value type of metadata property '{_oeh_cdi}': "
+                                f"{type(whitelist_keys)} . (Expected type: 'list[str]')"
+                            )
+                    else:
+                        log.error(
+                            f"Could not find '{_oeh_cdi}' in edu-sharing API response. "
+                            f"Source template retrieval FAILED!"
+                        )
+                        log.debug(response.text)
+                except KeyError as ke:
+                    raise ke
+
+                # the result dict with all whitelisted metadata properties might look like this example:
+                # _whitelisted_properties = {
+                #     "ccm:oeh_quality_login": ["1"],
+                #     "ccm:oeh_quality_protection_of_minors": ["0"],
+                #     "ccm:taxonid": [
+                #         "http://w3id.org/openeduhub/vocabs/discipline/720",
+                #         "http://w3id.org/openeduhub/vocabs/discipline/120",
+                #     ],
+                #     "cclom:general_keyword": ["Kinderlexikon", "Lexikon"],
+                # }
+
+                return _whitelisted_properties
+            else:
+                log.error(
+                    f"edu-sharing API returned an unexpected 'nodes'-object:"
+                    f"Expected list[dict] of length 1, received length: {len(nodes_list)} .\n"
+                    f"Please make sure that a 'source template' ('Quellendatensatz'-template) for crawler "
+                    f"{self._crawler_name} exists within the edu-sharing repository {self._edu_sharing_base_url} !"
+                )
+                return None
+        else:
+            # sad-case: we catch unexpected HTTP responses here
+            log.error(
+                f"Received unexpected HTTP response (status code: {status_code} ) from the edu-sharing "
+                f"repository while trying to retrieve whitelisted 'source template'-metadata-properties."
+            )
+            if status_code == 401:
+                # ToDo: specify exact edu-sharing version that provides the necessary API endpoint
+                log.error(
+                    f"edu-sharing API returned HTTP Status Code {status_code}. "
+                    f"(This might happen when the necessary API endpoint might not be available (yet) in the "
+                    f"edu-sharing repository (edu-sharing v8.1+ required).)"
+                )
+            if status_code == 500:
+                # code 500 might be accompanied by 'java.lang.NullPointerException' -> print whole response
+                # happens when the payload of our submitted request was empty
+                log.error(f"edu-sharing API returned HTTP status code {status_code}:\n" f"{response.text}")
+                response.raise_for_status()
+            # ToDo: extend Error-Handling for additional edge-cases (as / if they occur)
+            return None
+
+    def get_whitelisted_metadata_properties(self) -> dict | None:
+        """
+        Retrieve whitelisted metadata properties from a specified edu-sharing repository by using a 'source template'
+        (= "Quellen-Datensatz"-Template) which is expected to contain a "ccm:oeh_crawler_data_inherit"-property.
+
+        :return: a 'dict' containing whitelisted metadata property key-value pairs or None
+        """
+        # check user-defined .env Setting first if 'crawler source dataset' should be ignored:
+        est_enabled: bool = env.get_bool(key="EDU_SHARING_SOURCE_TEMPLATE_ENABLED", allow_null=True, default=None)
+        if est_enabled:
+            log.info(
+                f".env setting 'EDU_SHARING_SOURCE_TEMPLATE_ENABLED' is ACTIVE. Trying to retrieve whitelisted "
+                f"properties..."
+            )
+            self._payload = self._build_payload()
+            if self._payload:
+                whitelisted_properties: dict = self._retrieve_whitelisted_metadata_properties()
+                if whitelisted_properties:
+                    return whitelisted_properties
+                else:
+                    # intentionally raising a ValueError to stop a crawl process when the 'source template'-setting
+                    # is active. (If the .env variable is explicitly set, we expect whitelisted properties to be
+                    # available and DO NOT want to crawl without them.)
+                    raise ValueError(
+                        "Failed to retrieve whitelisted metadata properties from edu-sharing "
+                        "'source template' (= 'Quellendatensatz-Template')! "
+                        "Aborting crawl process..."
+                    )
+            else:
+                log.error(
+                    f"Could not build payload object to retrieve 'source template'-properties from "
+                    f"edu-sharing repository. "
+                    f"\nJSON Payload for crawler_name '{self._crawler_name}' was:\n"
+                    f"{self._payload}"
+                    f"\n(payload REQUIRES a valid 'crawler_name'!)"
+                )
+                log.info(
+                    "Aborting crawl... (If you didn't mean to retrieve an edu-sharing 'source template', please "
+                    "set the .env variable 'EDU_SHARING_SOURCE_TEMPLATE_ENABLED' to False!)"
+                )
+                return None
+        else:
+            # if the setting is explicitly disabled, do nothing -> continue with normal crawler behaviour
+            log.info(
+                f"Recognized '.env'-Setting EDU_SHARING_SOURCE_TEMPLATE_ENABLED: '{est_enabled}'.\n"
+                f"Crawler source dataset will be IGNORED. Continuing with default crawler behaviour..."
+            )
+            return None
+
+
+if __name__ == "__main__":
+    log.setLevel("DEBUG")
+    crawler_name_for_testing: str = "zum_deutschlernen_spider"
+    # crawler_name_for_testing: str = "does_not_exist_spider"
+    est_helper: EduSharingSourceTemplateHelper = EduSharingSourceTemplateHelper(crawler_name=crawler_name_for_testing)
+    whitelisted_props: dict | None = est_helper.get_whitelisted_metadata_properties()
+    print("Whitelisted properties: ")
+    pp(whitelisted_props, indent=4)

--- a/converter/web_tools.py
+++ b/converter/web_tools.py
@@ -206,7 +206,7 @@ class WebTools:
         async with async_playwright() as p:
             browser = await p.chromium.connect_over_cdp(endpoint_url=env.get("PLAYWRIGHT_WS_ENDPOINT"))
             page = await browser.new_page()
-            await page.goto(url, wait_until="domcontentloaded", timeout=90000)
+            await page.goto(url, wait_until="load", timeout=90000)
             # waits for a website to fire the DOMContentLoaded event or for a timeout of 90s
             # since waiting for 'networkidle' seems to cause timeouts
             content = await page.content()


### PR DESCRIPTION
This PR includes the following changes:
- new feature: attach whitelisted edu-sharing "source template" metadata properties to individually scraped items (see: `EduSharingSourceTemplateHelper` utility class)
  - (see: KDATAPORT-153)
- change: when `Playwright` is used (see: `converter/web_tools.py`) to crawl a website, wait until the `load`-event is being fired by the website 
  - (previous: `DOMContentLoaded`) before retrieving the HTML and taking a screenshot
- docs: updated `converter/.env.example` with documentation regarding the newly implemented `.env`-settings to control

## Feature description: edu-sharing "source template" metadata properties whitelist ("Quellen-Datensatz"-Templates für erbende Daten)

Edu-Sharing v8.1+ provides a new API endpoint to query whitelisted metadata properties that should be "mixed into" the collected metadata during scraping of individual items. There are several requirements, so here's the gist of the program flow:

- within the specified edu-sharing repository, there **needs** to exist a "Quellen-Datensatz" (crawler source dataset) available for the to-be-run crawler
  - e.g. if you want to mix in metadata for `zum_klexikon_spider` during a crawl process, you **need to make sure** that a learning object for this source exists, which contains two important properties:
    - the learning object needs to be a "Quellen-Datensatz" (identified by the edu-sharing property `cclom:general_identifier`, in this case: `"cclom:general_identifier": "zum_klexikon_spider")
    - now that this learning object is recognized as a "Quellen-Datensatz", the metadata property `ccm:oeh_crawler_data_inherit` **must** be available and should contain the desired (to be whitelisted) property names
- the list of metadata properties found within `ccm:oeh_crawler_data_inherit` is used to attach the key-value pairs to `BaseItem.custom` early in the processing pipeline
  - if the crawler scrapes more suitable metadata properties, the "mixed in" / whitelisted metadata property gets overwritten by the more precise (individually scraped) metadata
    - this means that the whitelisted metadata properties basically act as a fallback for items where no precise metadata can be scraped, but otherwise don't interfere with the normal crawling process

"Quellen-Datensätze" (roughly translated to "crawler source datasets") are managed by editors with metadata expertise and kept up to date by humans. The metadata of a "Quellen-Datensatz" is typically much larger than the desired amount of metadata properties, which should be whitelisted and attached to each individual item, which is why only a subset (as defined in `ccm:oeh_crawler_data_inherit`) of properties are "mixed in" to individually scraped items.

### How-To - `.env`-settings explained

Since not every edu-sharing instance might have a "Quellen-Datensatz" and the required `ccm:oeh_crawler_data_inherit` property available during runtime of a crawler, this feature is **disabled by default** and should only be enabled on a per-spider basis! You can control the behaviour of this feature with two environment variables:

- `EDU_SHARING_SOURCE_TEMPLATE_ENABLED` (optional, `bool`):
  - by default, this `.env`-setting is not active and commented-out (this equals `EDU_SHARING_SOURCE_TEMPLATE_ENABLED=False`
  - if you choose to explicitly enable this feature (`EDU_SHARING_SOURCE_TEMPLATE_ENABLED=True`):
    - the crawler pipeline will check if a "Quellen-Datensatz"-Template is available within your specified edu-sharing repository 
    - and **raise an error** if retrieval of the whitelisted metadata properties failed for whatever reason and **abort the crawling process**
    - (the behavior of this feature in the program flow was intentionally chosen this way so that you cannot start a crawl with the "source template"-feature enabled and accidentally fail to attach the whitelisted properties.)
- `EDU_SHARING_SOURCE_TEMPLATE_BASE_URL` (optional, `str`):
  - this optional setting is mainly intended for those cases, when the edu-sharing repository where the "Quellen-Datensatz"-Template resides in is different from the edu-sharing repository you're saving the individual items to
    - e.g. during debugging if you want to query the "Staging"-environment for a "Quellen-Datensatz"-Template, but the invidually scraped items are saved to the "pre-Staging"-dev-environment
  - if you don't explicitly set a value for this variable (= an edu-sharing repository URL), the `EduSharingSourceTemplateHelper`-class will try to fall back to your edu-sharing repository as specified in `EDU_SHARING_BASE_URL` and use that one instead
  - if neither `EDU_SHARING_SOURCE_TEMPLATE_BASE_URL` nor `EDU_SHARING_BASE_URL` contains a valid setting, this feature cannot work properly and will raise an error!