### PR TITLE
ITSJOINTLY-1323 - add new channels and support "YouTube Handle" URLs

### DIFF
--- a/converter/spiders/youtube_spider.py
+++ b/converter/spiders/youtube_spider.py
@@ -54,7 +54,10 @@ class YoutubeSpider(Spider):
     name = "youtube_spider"
     friendlyName = "Youtube"
     url = "https://www.youtube.com/"
-    version = "0.2.3"  # last update: 2022-04-09
+    version = "0.2.3"  # last update: 2022-04-10
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False
+    }
 
     @staticmethod
     def get_video_url(item: dict) -> str:

--- a/converter/spiders/youtube_spider.py
+++ b/converter/spiders/youtube_spider.py
@@ -24,6 +24,28 @@ from .base_classes import LomBase, CSVBase
 # TODO: Find out whether `publishedAt` reflects modification
 #   - Find another way to set `hash` if not
 #
+# ToDo: "YouTube Handle" URLs: update URL parsing and implement handle-specific channel request parameter ('forHandle')
+#   - see: https://support.google.com/youtube/answer/6180214
+#     (Example: "youtube.com/@youtubecreators" requires different API parameters when querying "Channels: list"-endpoint
+#     https://developers-dot-devsite-v2-prod.appspot.com/youtube/v3/docs/channels/list )
+#
+# ToDo: YouTube API - Captions for fulltext extraction
+#   - see: https://developers.google.com/youtube/v3/docs/captions
+#   - PREREQUISITE: YouTube's "captions.download"-method REQUIRES OAuth 2.0 authentication (!!!)
+#     - (the current approach with a YT API Key DOES NOT work for this API endpoint!
+#        see: https://developers.google.com/youtube/v3/docs/captions/download#auth)
+#   - query 'captions'-API-endpoint with individual YT 'videoId' to receive a list of caption ids
+#     (see: https://developers.google.com/youtube/v3/docs/captions/list)
+#     IMPORTANT: API quota cost: 50 units per query!
+#     From the API response:
+#       - decide which specific language (order: German > English > ?) to download
+#       - decide which of the available subtitle formats (which format should we prefer? .ttml or .srt?) to download
+#   - query Captions API endpoint to download caption file
+#     (see: https://developers.google.com/youtube/v3/docs/captions/download)
+#     IMPORTANT: API quota cost: 200 units per query!
+#   - save captions to 'BaseItem.fulltext'
+#     (to make the fulltext available within edu-sharing's ElasticSearch index (within the 'content.fulltext' property))
+
 
 class YoutubeSpider(Spider):
     """
@@ -55,9 +77,7 @@ class YoutubeSpider(Spider):
 
     @staticmethod
     def get_csv_rows(filename: str) -> Generator[dict, None, None]:
-        csv_file_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "csv", filename)
-        )
+        csv_file_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "csv", filename))
         with open(csv_file_path, newline="", encoding="utf-8") as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
@@ -74,39 +94,49 @@ class YoutubeSpider(Spider):
             return
         if env.get(key="YOUTUBE_LIMITED_CRAWL_URL", allow_null=True, default=None) == "":
             # If no value is set, this serves as a reminder that you can disable the '.env'-variable altogether
-            logging.debug("The '.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' was detected, but no URL was set. \n"
-                          "If you meant to start a LIMITED crawl, please check your '.env'-file and restart the "
-                          "crawler. The crawler is now commencing with a COMPLETE crawl according to the "
-                          "'csv/youtube.csv'-table.")
+            logging.debug(
+                "The '.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' was detected, but no URL was set. \n"
+                "If you meant to start a LIMITED crawl, please check your '.env'-file and restart the "
+                "crawler. The crawler is now commencing with a COMPLETE crawl according to the "
+                "'csv/youtube.csv'-table."
+            )
         if env.get(key="YOUTUBE_LIMITED_CRAWL_URL", allow_null=True, default=None):
             # the OPTIONAL .env parameter is used to crawl from a SINGULAR URL ONLY
-            logging.debug("'.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' recognized. LIMITED crawling mode activated!\n"
-                          "(This mode WILL NOT crawl the complete 'csv/youtube.csv'-file, but only a SINGLE YouTube "
-                          "channel or playlist!)\n"
-                          "If you actually wanted to start a complete/full crawl, please disable the variable in your "
-                          "'.env'-file.")
+            logging.debug(
+                "'.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' recognized. LIMITED crawling mode activated!\n"
+                "(This mode WILL NOT crawl the complete 'csv/youtube.csv'-file, but only a SINGLE YouTube "
+                "channel or playlist!)\n"
+                "If you actually wanted to start a complete/full crawl, please disable the variable in your "
+                "'.env'-file."
+            )
             singular_crawl_target_url: str = env.get(key="YOUTUBE_LIMITED_CRAWL_URL", default=None)
             if singular_crawl_target_url:
-                logging.debug(f"'.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' is set to: {singular_crawl_target_url} \n"
-                              f"Searching for {singular_crawl_target_url} within 'csv/youtube.csv' for metadata values.")
+                logging.debug(
+                    f"'.env'-variable 'YOUTUBE_LIMITED_CRAWL_URL' is set to: {singular_crawl_target_url} \n"
+                    f"Searching for {singular_crawl_target_url} within 'csv/youtube.csv' for metadata values."
+                )
                 match_found: bool = False
                 for row in YoutubeSpider.get_csv_rows("youtube.csv"):
                     if row["url"] == singular_crawl_target_url:
-                        # ToDo (optional): several YouTube URLs (youtu.be, youtube.com / youtube.de) can point to the same
-                        #  channel or playlist. Providing some leniency by resolving an URL to the "real" target might
-                        #  provide some Quality of Life while using this feature.
+                        # ToDo (optional): several YouTube URLs (youtu.be, youtube.com / youtube.de)
+                        #  can point to the same channel or playlist. Providing some leniency by resolving an URL to
+                        #  the "real" target might provide some Quality of Life while using this feature.
                         match_found = True
-                        logging.debug(f"Match found in 'csv/youtube.csv' for {singular_crawl_target_url}! Commencing"
-                                      f"SINGULAR crawl process.")
+                        logging.debug(
+                            f"Match found in 'csv/youtube.csv' for {singular_crawl_target_url}! Commencing"
+                            f"SINGULAR crawl process."
+                        )
                         request = self.request_row(row)
                         if request:
                             # we are expecting exactly one result, therefore we can stop looking after the first match
                             yield request
                             break
                 if match_found is False:
-                    logging.error(f"Could not find a match for {singular_crawl_target_url} within 'csv/youtube.csv'. "
-                                  f"Please confirm that the EXACT specified URL can be found in a row of the CSV and "
-                                  f"restart the crawler.")
+                    logging.error(
+                        f"Could not find a match for {singular_crawl_target_url} within 'csv/youtube.csv'. "
+                        f"Please confirm that the EXACT specified URL can be found in a row of the CSV and "
+                        f"restart the crawler."
+                    )
                     return
         else:
             # this is where the COMPLETE crawl happens: requests are yielded row-by-row from 'csv/youtube.csv'
@@ -134,17 +164,16 @@ class YoutubeSpider(Spider):
                 # All of these lead to an ordinary channel, but we need to read its ID from the page
                 # body.
                 return Request(
-                    row["url"], meta={"row": row}, callback=self.parse_custom_url,
+                    row["url"],
+                    meta={"row": row},
+                    callback=self.parse_custom_url,
                 )
 
     def request_channel(self, channel_id: str, meta: dict) -> Request:
         part = ["snippet", "contentDetails", "statistics"]
         # see: https://developers.google.com/youtube/v3/docs/channels
-        request_url = (
-                "https://www.googleapis.com/youtube/v3/channels"
-                + "?part={}&id={}&key={}".format(
+        request_url = "https://www.googleapis.com/youtube/v3/channels" + "?part={}&id={}&key={}".format(
             "%2C".join(part), channel_id, env.get("YOUTUBE_API_KEY", False)
-        )
         )
         return Request(url=request_url, meta=meta, callback=self.parse_channel)
 
@@ -160,11 +189,10 @@ class YoutubeSpider(Spider):
     def request_playlist(self, playlist_id: str, meta: dict) -> Request:
         part = ["snippet"]
         # see: https://developers.google.com/youtube/v3/docs/playlists
-        request_url = (
-                "https://www.googleapis.com/youtube/v3/playlists"
-                + "?part={}&id={}&key={}".format(
-            "%2C".join(part), playlist_id, env.get("YOUTUBE_API_KEY"),
-        )
+        request_url = "https://www.googleapis.com/youtube/v3/playlists" + "?part={}&id={}&key={}".format(
+            "%2C".join(part),
+            playlist_id,
+            env.get("YOUTUBE_API_KEY"),
         )
         return Request(request_url, meta=meta, callback=self.parse_playlist)
 
@@ -178,11 +206,10 @@ class YoutubeSpider(Spider):
     def request_playlist_items(self, playlist_id: str, meta: dict) -> Request:
         part = ["snippet"]
         # see: https://developers.google.com/youtube/v3/docs/playlistItems
-        request_url = (
-            "https://www.googleapis.com/youtube/v3/playlistItems"
-            + "?part={}&playlistId={}&key={}".format(
-                "%2C".join(part), playlist_id, env.get("YOUTUBE_API_KEY"),
-            )
+        request_url = "https://www.googleapis.com/youtube/v3/playlistItems" + "?part={}&playlistId={}&key={}".format(
+            "%2C".join(part),
+            playlist_id,
+            env.get("YOUTUBE_API_KEY"),
         )
         return Request(request_url, meta=meta, callback=self.parse_playlist_items)
 
@@ -192,21 +219,16 @@ class YoutubeSpider(Spider):
         ids = [item["snippet"]["resourceId"]["videoId"] for item in body["items"]]
         yield self.request_videos(ids, response.meta)
         if "nextPageToken" in body:
-            request_url = YoutubeSpider.update_url_query(
-                response.url, {"pageToken": body["nextPageToken"]}
-            )
-            yield response.follow(
-                request_url, meta=response.meta, callback=self.parse_playlist_items
-            )
+            request_url = YoutubeSpider.update_url_query(response.url, {"pageToken": body["nextPageToken"]})
+            yield response.follow(request_url, meta=response.meta, callback=self.parse_playlist_items)
 
     def request_videos(self, ids: List[str], meta: dict):
         part = ["snippet", "status", "contentDetails"]
         # see: https://developers.google.com/youtube/v3/docs/videos
-        request_url = (
-            "https://www.googleapis.com/youtube/v3/videos"
-            + "?part={}&id={}&key={}".format(
-                "%2C".join(part), "%2C".join(ids), env.get("YOUTUBE_API_KEY"),
-            )
+        request_url = "https://www.googleapis.com/youtube/v3/videos" + "?part={}&id={}&key={}".format(
+            "%2C".join(part),
+            "%2C".join(ids),
+            env.get("YOUTUBE_API_KEY"),
         )
         return Request(request_url, meta=meta, callback=self.parse_videos)
 
@@ -231,7 +253,7 @@ class YoutubeLomLoader(LomBase):
     # The `response.meta` field is populated as follows:
     #   - `row`: The row of the CSV file containing the channel or playlist to be scraped with some
     #     additional information regarding all found videos.
-    #   - `item`: Information about the video, obtained from the Youtube API.
+    #   - `item`: Information about the video, obtained from the YouTube API.
     #   - `channel`: Information about the YouTube channel, obtained from the YouTube API. Only
     #     populated if an entire channel was given in the CSV row.
     #   - `playlist`: Information about the YouTube playlist, obtained from the YouTube API. This
@@ -268,22 +290,20 @@ class YoutubeLomLoader(LomBase):
         base = LomBase.getBase(self, response)
         base.add_value("origin", response.meta["row"]["sourceTitle"].strip())
         base.add_value("lastModified", response.meta["item"]["snippet"]["publishedAt"])
-        base.add_value("thumbnail", self.getThumbnailUrl(response))
-        base.add_value("fulltext", self.getFulltext(response))
+        base.add_value("thumbnail", self.get_thumbnail_url(response))
+        base.add_value("fulltext", self.get_fulltext(response))
         return base
 
-    def getThumbnailUrl(self, response: Response) -> str:
+    def get_thumbnail_url(self, response: Response) -> str:
         thumbnails = response.meta["item"]["snippet"]["thumbnails"]
         thumbnail = (
             thumbnails["maxres"]
             if "maxres" in thumbnails
-            else thumbnails["standard"]
-            if "standard" in thumbnails
-            else thumbnails["high"]
+            else thumbnails["standard"] if "standard" in thumbnails else thumbnails["high"]
         )
         return thumbnail["url"]
 
-    def getFulltext(self, response: Response) -> str:
+    def get_fulltext(self, response: Response) -> str:
         item = response.meta["item"]["snippet"]
         # If `channel` is populated, it has more relevant information than `playlist` (see comments
         # to `meta` field above).
@@ -295,7 +315,11 @@ class YoutubeLomLoader(LomBase):
         else:
             playlist = response.meta["playlist"]["snippet"]
             fulltext = "\n\n".join(
-                [playlist["channelTitle"], playlist["title"], playlist["description"],],
+                [
+                    playlist["channelTitle"],
+                    playlist["title"],
+                    playlist["description"],
+                ],
             )
         return fulltext
 
@@ -303,18 +327,14 @@ class YoutubeLomLoader(LomBase):
     def getLOMGeneral(self, response: Response) -> items.LomGeneralItemloader:
         general = LomBase.getLOMGeneral(self, response)
         general.add_value("title", response.meta["item"]["snippet"]["title"])
-        general.add_value("description", self.getDescription(response))
-        general.add_value(
-            "keyword", self.parse_csv_field(response.meta["row"]["keyword"])
-        )
+        general.add_value("description", self.get_description(response))
+        general.add_value("keyword", self.parse_csv_field(response.meta["row"]["keyword"]))
         if "tags" in response.meta["item"]["snippet"]:
             general.add_value("keyword", response.meta["item"]["snippet"]["tags"])
-        general.add_value(
-            "language", self.parse_csv_field(response.meta["row"]["language"])
-        )
+        general.add_value("language", self.parse_csv_field(response.meta["row"]["language"]))
         return general
 
-    def getDescription(self, response: Response) -> str:
+    def get_description(self, response: Response) -> str:
         return (
             response.meta["item"]["snippet"]["description"]
             # Fall back to playlist title when no description was given.
@@ -325,26 +345,16 @@ class YoutubeLomLoader(LomBase):
     def getLOMTechnical(self, response: Response) -> items.LomTechnicalItemLoader:
         technical = LomBase.getLOMTechnical(self, response)
         technical.add_value("format", "text/html")
-        technical.add_value(
-            "location", YoutubeSpider.get_video_url(response.meta["item"])
-        )
-        technical.add_value(
-            "duration", response.meta["item"]["contentDetails"]["duration"]
-        )
+        technical.add_value("location", YoutubeSpider.get_video_url(response.meta["item"]))
+        technical.add_value("duration", response.meta["item"]["contentDetails"]["duration"])
         return technical
 
     @overrides  # LomBase
     def getLOMEducational(self, response):
         educational = LomBase.getLOMEducational(self, response)
         tar = items.LomAgeRangeItemLoader()
-        tar.add_value(
-            "fromRange",
-            self.parse_csv_field(response.meta["row"][CSVBase.COLUMN_TYPICAL_AGE_RANGE_FROM])
-        )
-        tar.add_value(
-            "toRange",
-            self.parse_csv_field(response.meta["row"][CSVBase.COLUMN_TYPICAL_AGE_RANGE_TO])
-        )
+        tar.add_value("fromRange", self.parse_csv_field(response.meta["row"][CSVBase.COLUMN_TYPICAL_AGE_RANGE_FROM]))
+        tar.add_value("toRange", self.parse_csv_field(response.meta["row"][CSVBase.COLUMN_TYPICAL_AGE_RANGE_TO]))
         educational.add_value("typicalAgeRange", tar.load_item())
         return educational
 
@@ -352,17 +362,15 @@ class YoutubeLomLoader(LomBase):
     def getLOMLifecycle(self, response: Response) -> items.LomLifecycleItemloader:
         lifecycle = LomBase.getLOMLifecycle(self, response)
         lifecycle.add_value("role", "author")
-        lifecycle.add_value(
-            "organization", response.meta["item"]["snippet"]["channelTitle"]
-        )
-        lifecycle.add_value("url", self.getChannelUrl(response))
+        lifecycle.add_value("organization", response.meta["item"]["snippet"]["channelTitle"])
+        lifecycle.add_value("url", self.get_channel_url(response))
         yield lifecycle
         lifecycle = LomBase.getLOMLifecycle(self, response)
         lifecycle.add_value("role", "publisher")
         lifecycle.add_value("date", response.meta["item"]["snippet"]["publishedAt"])
         yield lifecycle
 
-    def getChannelUrl(self, response: Response) -> str:
+    def get_channel_url(self, response: Response) -> str:
         channel_id = response.meta["item"]["snippet"]["channelId"]
         return "https://www.youtube.com/channel/{}".format(channel_id)
 
@@ -372,9 +380,7 @@ class YoutubeLomLoader(LomBase):
         # there are only two possible values according to https://developers.google.com/youtube/v3/docs/videos:
         #   "youtube", "creativeCommon"
         if response.meta["item"]["status"]["license"] == "creativeCommon":
-            license_loader.add_value(
-                "url", Constants.LICENSE_CC_BY_30
-            )
+            license_loader.add_value("url", Constants.LICENSE_CC_BY_30)
         elif response.meta["item"]["status"]["license"] == "youtube":
             license_loader.replace_value("internal", Constants.LICENSE_CUSTOM)
             license_loader.add_value("description", "Youtube-Standardlizenz")
@@ -387,14 +393,17 @@ class YoutubeLomLoader(LomBase):
         valuespaces = LomBase.getValuespaces(self, response)
         row = response.meta["row"]
         valuespaces.add_value(
-            "learningResourceType", self.parse_csv_field(row["learningResourceType"]),
+            "learningResourceType",
+            self.parse_csv_field(row["learningResourceType"]),
         )
         valuespaces.add_value("discipline", self.parse_csv_field(row["discipline"]))
         valuespaces.add_value(
-            "intendedEndUserRole", self.parse_csv_field(row["intendedEndUserRole"]),
+            "intendedEndUserRole",
+            self.parse_csv_field(row["intendedEndUserRole"]),
         )
         valuespaces.add_value(
-            "educationalContext", self.parse_csv_field(row[CSVBase.COLUMN_EDUCATIONAL_CONTEXT]),
+            "educationalContext",
+            self.parse_csv_field(row[CSVBase.COLUMN_EDUCATIONAL_CONTEXT]),
         )
         if "fskRating" in response.meta["item"]["contentDetails"]:
             # the majority of videos doesn't have a fskRating, but if they do, we try to map the YT values to our vocab:

--- a/csv/youtube.csv
+++ b/csv/youtube.csv
@@ -61,6 +61,7 @@ https://www.youtube.com/channel/UComfd9z6KFVP3nggiME6-7w/featured,German as a Fo
 https://www.youtube.com/channel/UC7mZyCH5ppdYdJrHuxjJtkw/featured,Educational Robotics,video,"320, 04005",,teacher; learner,16,99,de; en,,
 ,,,,,,,,,,
 ,,,,,,,,,,
+,,,,,,,,,,
 Playlists,,,,,,,,,,
 https://www.youtube.com/playlist?list=PLC9D2mzTyJeXYa6E1y_d0fc_7-V7BJnSq,DigiFernunterricht,video,720,,teacher,18,99,de,,
 https://www.youtube.com/playlist?list=PLFhPjADeGDodbVSSL8LE00SNjQIPiyamr,Webinare Deutsches Lehrkräfteforum,video,720,,teacher,18,99,de,,
@@ -206,3 +207,7 @@ https://www.youtube.com/channel/UCFSS2FtaFNKMei4jGQOVL3w,Chemie und Bio in der S
 https://www.youtube.com/channel/UCk0aUAhu9RxfOX1iMXAJ-2g,Chemistry Kicksass,video,100,Sekundarstufe 1; Sekundarstufe 2,learner,,,de,,
 https://www.youtube.com/channel/UCWNvo3l-K-X6CPSBcP9NCNg,Chemie - simpleclub,video,100,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,,,de,,
 https://www.youtube.com/channel/UC1a400owZ_Qa-3Ood22cMKg,Ecole Science,video,460,Sekundarstufe 1; Sekundarstufe 2,teacher; learner,10,99,de,,
+,,,,,,,,,,
+https://www.youtube.com/@Unkauf_MC,Sehen & Verstehen - Experimente und meeehr,video,100; 04003; 080; 460,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,99,de,,15.03.2024
+https://www.youtube.com/@MathemaTrick,MathemaTrick,video,380,Sekundarstufe 1; Sekundarstufe 2,learner; teacher; parent,10,99,de,,15.03.2024
+https://www.youtube.com/@pharithmetik,Christian Spannagel,video,380,Sekundarstufe 1; Sekundarstufe 2,learner; teacher,10,99,de,,15.03.2024


### PR DESCRIPTION
This PR includes the following changes with regard to ITSJOINTLY-1323:
- added 3 YouTube channels to `csv/youtube.csv`:
  - "Sehen & Verstehen - Experimente und meeehr"
  - "MathemaTrick"
  - "Christian Spannagel"
- `youtube_spider` v0.2.3:
  - added support for "YouTube Handle" URL patterns (German: "Alias"-URLs, e.g., `https://www.youtube.com/@MathemaTrick`)
    - custom URLs (e.g., `https://www.youtube.com/c/sehenverstehenexperimenteundmeeehr/`) are no longer actively supported by YouTube and are [effectively replaced by Handle URLs](https://support.google.com/youtube/answer/2657968), see: 
      - [YouTube Help - Understand your YouTube channel's URLs](https://support.google.com/youtube/answer/6180214?hl=en&sjid=8649083492401077263-EU)
      - [YouTube Help - Handles overview](https://support.google.com/youtube/answer/11585688?hl=en&sjid=1154139518236355177-EU)
  - reworked the previous approach to custom URL handling (making an HTTP request and parsing the HTTP body for a `channel_id` property) with a RegEx pattern:
    - previously, our crawler was able to determine `channel_id` (which was necessary for subsequent requests) by doing an HTTP `GET`-request and parsing a specific "channel ID"-property in the HTML body of the response
    - since this approach no longer works reliably (YouTube actively redirects (HTTP Status: 302) to a cookie consent / data protection **pre-page**), custom URLs in the legacy format will throw a Warning from now on and **should be transformed to URLs in the "YouTube Handle" pattern** before saving them to `csv/youtube.csv`
  - fixed several (weak) warnings
  - style: minor code formatting changes and refactoring to make the code more pythonic