### PR TITLE
Merge oersi_spider v0.2.7 and bne_portal_spider v0.0.3 into develop

### DIFF
--- a/.run/bne_portal_spider.run.xml
+++ b/.run/bne_portal_spider.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bne_portal_spider" type="PythonConfigurationType" factoryName="Python">
+    <output_file path="$PROJECT_DIR$/logs/bne_portal_spider_console.log" is_save="true" />
+    <module name="oeh-search-etl" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="./.venv/bin/scrapy" />
+    <option name="PARAMETERS" value="crawl bne_portal_spider -O &quot;../../logs/bne_portal_spider.json&quot;" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -482,7 +482,7 @@ class EduSharing:
                     # To set "ADR"-attributes and values, we need to create an "Address"-object first
                     # see: https://github.com/py-vobject/vobject/blob/master/vobject/vcard.py#L54-L66
                     # ToDo: implement "address"-pipeline
-                    #  (the vobject package expects a str or list[str] for these proeprties!)
+                    #  (the vobject package expects a str or list[str] for these properties!)
                     address_object: vobject.vcard.Address = vobject.vcard.Address(street=address_street,
                                                                                   city=address_city,
                                                                                   region=address_region,
@@ -566,12 +566,20 @@ class EduSharing:
                 splitted = valuespaceMapping[key].split(":")
                 splitted[0] = "virtual"
                 spaces[":".join(splitted)] = item["valuespaces_raw"][key]
-        if "typicalAgeRange" in item["lom"]["educational"]:
-            tar = item["lom"]["educational"]["typicalAgeRange"]
-            if "fromRange" in tar:
-                spaces["ccm:educationaltypicalagerange_from"] = tar["fromRange"]
-            if "toRange" in tar:
-                spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
+
+        if "educational" in item["lom"]:
+            if "description" in item["lom"]["educational"]:
+                educational_description: list[str] = item["lom"]["educational"]["description"]
+                if educational_description:
+                    # ToDo: implement "description"-pipeline (in pipelines.py)
+                    spaces["cclom:educational_description"] = educational_description
+                pass
+            if "typicalAgeRange" in item["lom"]["educational"]:
+                tar = item["lom"]["educational"]["typicalAgeRange"]
+                if "fromRange" in tar:
+                    spaces["ccm:educationaltypicalagerange_from"] = tar["fromRange"]
+                if "toRange" in tar:
+                    spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
 
         if "course" in item:
             if "course_availability_from" in item["course"]:

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -583,10 +583,13 @@ class EduSharing:
             if "course_description_short" in item["course"]:
                 spaces["ccm:oeh_course_description_short"] = item["course"]["course_description_short"]
             if "course_duration" in item["course"]:
-                course_duration: int = item["course"]["course_duration"]
+                course_duration: int | str = item["course"]["course_duration"]
+                if course_duration and isinstance(course_duration, str) and course_duration.isnumeric():
+                    # convert strings to int values
+                    course_duration = int(course_duration)
                 if course_duration and isinstance(course_duration, int):
                     # edu-sharing property 'cclom:typicallearningtime' expects values in ms!
-                    course_duration_in_ms = int(course_duration * 1000)
+                    course_duration_in_ms: int = int(course_duration * 1000)
                     item["course"]["course_duration"] = course_duration_in_ms
                     spaces["cclom:typicallearningtime"] = item["course"]["course_duration"]
                 else:

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -593,7 +593,13 @@ class EduSharing:
                     log.warning(f"Could not transform 'course_duration' {course_duration} to ms. "
                                 f"Expected int (seconds), but received type {type(course_duration)} instead.")
             if "course_learningoutcome" in item["course"]:
-                spaces["ccm:learninggoal"] = item["course"]["course_learningoutcome"]
+                course_learning_outcome: list[str] = item["course"]["course_learningoutcome"]
+                if course_learning_outcome and isinstance(course_learning_outcome, list):
+                    # convert the array of strings to a single string, divided by semicolons
+                    course_learning_outcome: str = "; ".join(course_learning_outcome)
+                if course_learning_outcome and isinstance(course_learning_outcome, str):
+                    # edu-sharing expects a string value for this field
+                    spaces["ccm:learninggoal"] = course_learning_outcome
             if "course_schedule" in item["course"]:
                 spaces["ccm:oeh_course_schedule"] = item["course"]["course_schedule"]
             if "course_url_video" in item["course"]:

--- a/converter/items.py
+++ b/converter/items.py
@@ -348,7 +348,7 @@ class CourseItem(Item):
     Corresponding edu-sharing property: 'cclom:typicallearningtime'.
     (ATTENTION: edu-sharing expects 'cclom:typicallearningtime'-values (type: int) in milliseconds! 
     -> the es_connector will handle transformation from s to ms.)"""
-    course_learningoutcome = Field()
+    course_learningoutcome = Field(output_processor=JoinMultivalues())
     """Describes "Lernergebnisse" or "learning objectives". (Expects a string, with or without HTML-formatting!)
     Corresponding edu-sharing property: 'ccm:learninggoal'"""
     course_schedule = Field()

--- a/converter/items.py
+++ b/converter/items.py
@@ -159,8 +159,8 @@ class LomEducationalItem(Item):
     - context                   (see: 'valuespaces.educationalContext')
     """
 
-    description = Field()
-    # ToDo: 'description' isn't mapped to any field in edu-sharing
+    description = Field(output_processor=JoinMultivalues())
+    """Corresponding edu-sharing property: 'cclom:educational_description'"""
     difficulty = Field()
     """Corresponding edu-sharing property: 'ccm:educationaldifficulty'"""
     # ToDo: 'ccm:educationaldifficulty' is currently not used in edu-sharing / WLO

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -297,7 +297,7 @@ def determine_duration_and_convert_to_seconds(time_raw: str | int | float,
     @param item_field_name: scrapy item field-name (required for precise logging messages)
     @return: total seconds (int) value of duration or None
     """
-    time_in_seconds = None
+    time_in_seconds: int | None = None
     # why are we converting values to int? reason: 'cclom:typicallearningtime' expects values to be in milliseconds!
     # (this method converts values to seconds and es_connector.py converts the values to ms)
     if time_raw and isinstance(time_raw, str):

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -237,9 +237,18 @@ class NormLicensePipeline(BasicPipeline):
         if "expirationDate" in item["license"]:
             item["license"]["expirationDate"] = dateparser.parse(item["license"]["expirationDate"])
         if "lifecycle" in item["lom"]:
-            for contribute in item["lom"]["lifecycle"]:
-                if "date" in contribute:
-                    contribute["date"] = dateparser.parse(contribute["date"])
+            for lifecycle_contributor in item["lom"]["lifecycle"]:
+                # there can be multiple LomLifecycleItems within a LomBaseItem
+                if "date" in lifecycle_contributor:
+                    lifecycle_date: str | datetime.datetime = lifecycle_contributor["date"]
+                    if lifecycle_date and isinstance(lifecycle_date, str):
+                        lifecycle_contributor["date"] = dateparser.parse(lifecycle_date)
+                    elif lifecycle_date and isinstance(lifecycle_date, datetime.datetime):
+                        # happy-case: the 'date' property is of type datetime
+                        pass
+                    elif lifecycle_date:
+                        log.warning(f"Lifecycle Pipeline received invalid 'date'-value: {lifecycle_date} !"
+                                    f"Expected type 'str' or 'datetime', but received: {type(lifecycle_date)} instead.")
 
         return raw_item
 

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -589,6 +589,10 @@ class ProcessThumbnailPipeline(BasicPipeline):
     """
     generate thumbnails
     """
+    pixel_limit: int = 178956970  # ~179 Megapixel
+    pixel_limit_in_mp: float = pixel_limit / 1000000
+    Image.MAX_IMAGE_PIXELS = pixel_limit  # doubles the Pillow default (89,478,485) → from 89,5 MegaPixels to 179 MP
+    # see: https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS
 
     @staticmethod
     def scale_image(img, max_size):
@@ -603,14 +607,15 @@ class ProcessThumbnailPipeline(BasicPipeline):
         """
         By default, the thumbnail-pipeline handles several cases:
         - if there is a URL-string inside the "BaseItem.thumbnail"-field:
-        -- download image from URL; rescale it into different sizes (small/large);
-        --- save the thumbnails as base64 within
-        ---- "BaseItem.thumbnail.small", "BaseItem.thumbnail.large"
-        --- (afterward delete the URL from "BaseItem.thumbnail")
+            - download image from URL; rescale it into different sizes (small/large);
+                - save the thumbnails as base64 within
+                    - "BaseItem.thumbnail.small"
+                    - "BaseItem.thumbnail.large"
+                - (afterward delete the URL from "BaseItem.thumbnail")
 
         - if there is NO "BaseItem.thumbnail"-field:
-        -- default: take a screenshot of the URL from "technical.location" with Splash, rescale and save (as above)
-        -- alternatively, on-demand: use Playwright to take a screenshot, rescale and save (as above)
+            - default: take a screenshot of the URL from "technical.location" (with Splash), rescale and save (as above)
+            - alternatively, on-demand: use Playwright to take a screenshot, rescale and save (as above)
         """
         item = ItemAdapter(raw_item)
         response: scrapy.http.Response | None = None
@@ -653,9 +658,9 @@ class ProcessThumbnailPipeline(BasicPipeline):
             log.debug(f"Loading thumbnail from {url} took {time_end - time_start} (incl. awaiting).")
             log.debug(f"Thumbnail-URL-Cache: {self.download_thumbnail_url.cache_info()} after trying to query {url} ")
             if thumbnail_response.status != 200:
-                log.debug(f"Thumbnail-Pipeline received a unexpected response (status: {thumbnail_response.status}) "
+                log.debug(f"Thumbnail-Pipeline received an unexpected response (status: {thumbnail_response.status}) "
                           f"from {url} (-> resolved URL: {thumbnail_response.url}")
-                # fall back to website screenshot
+                # falling back to website screenshot:
                 del item["thumbnail"]
                 return await self.process_item(raw_item, spider)
             else:
@@ -740,8 +745,21 @@ class ProcessThumbnailPipeline(BasicPipeline):
                 # this edge-case is necessary for spiders that only need playwright to gather a screenshot,
                 # but don't use playwright within the spider itself
                 target_url: str = item["lom"]["technical"]["location"][0]
+
+                playwright_cookies = None
+                playwright_adblock_enabled = False
+                if spider.custom_settings:
+                    # some spiders might require setting specific cookies to take "clean" website screenshots
+                    # (= without cookie banners or ads).
+                    if "PLAYWRIGHT_COOKIES" in spider.custom_settings:
+                        playwright_cookies = spider.custom_settings.get("PLAYWRIGHT_COOKIES")
+                    if "PLAYWRIGHT_ADBLOCKER" in spider.custom_settings:
+                        playwright_adblock_enabled: bool = spider.custom_settings["PLAYWRIGHT_ADBLOCKER"]
+
                 playwright_dict = await WebTools.getUrlData(url=target_url,
-                                                            engine=WebEngine.Playwright)
+                                                            engine=WebEngine.Playwright,
+                                                            cookies=playwright_cookies,
+                                                            adblock=playwright_adblock_enabled)
                 screenshot_bytes = playwright_dict.get("screenshot_bytes")
                 img = Image.open(BytesIO(screenshot_bytes))
                 self.create_thumbnails_from_image_bytes(img, item, settings_crawler)
@@ -777,15 +795,29 @@ class ProcessThumbnailPipeline(BasicPipeline):
                         response.body
                     ).decode()
                 else:
-                    img = Image.open(BytesIO(response.body))
-                    self.create_thumbnails_from_image_bytes(img, item, settings_crawler)
-            except PIL.UnidentifiedImageError:
-                # this error can be observed when a website serves broken / malformed images
-                if url:
-                    log.warning(f"Thumbnail download of image file {url} failed: image file could not be identified "
+                    try:
+                        img = Image.open(BytesIO(response.body))
+                        self.create_thumbnails_from_image_bytes(img, item, settings_crawler)
+                    except PIL.UnidentifiedImageError:
+                        # this error can be observed when a website serves broken / malformed images
+                        if url:
+                            log.warning(
+                                f"Thumbnail download of image file {url} failed: image file could not be identified "
                                 f"(Image might be broken or corrupt). Falling back to website-screenshot.")
-                del item["thumbnail"]
-                return await self.process_item(raw_item, spider)
+                        del item["thumbnail"]
+                        return await self.process_item(raw_item, spider)
+                    except Image.DecompressionBombError:
+                        # Pillow throws a "DecompressionBombError" if the downloaded image exceeds twice the
+                        # "Image.MAX_IMAGE_PIXELS"-setting.
+                        # If such an error is thrown, the image object won't be available.
+                        # Therefore, we need to fall back to a website screenshot.
+                        absolute_pixel_limit_in_mp = (self.pixel_limit * 2) / 1000000
+                        log.warning(f"Thumbnail download of {url} triggered a 'PIL.Image.DecompressionBombError'! "
+                                    f"The image either exceeds the max size of {absolute_pixel_limit_in_mp} "
+                                    f"megapixels or might have been a DoS attempt. "
+                                    f"Falling back to website screenshot...")
+                        del item["thumbnail"]
+                        return await self.process_item(raw_item, spider)
             except Exception as e:
                 if url is not None:
                     log.warning(f"Could not read thumbnail at {url}: {str(e)} (falling back to screenshot)")

--- a/converter/spiders/bne_portal_spider.py
+++ b/converter/spiders/bne_portal_spider.py
@@ -1,0 +1,480 @@
+import datetime
+import re
+from typing import Iterable
+
+import scrapy
+import trafilatura
+from scrapy import Request
+
+from converter.constants import Constants
+from converter.items import (
+    BaseItemLoader,
+    LomBaseItemloader,
+    LomGeneralItemloader,
+    LomTechnicalItemLoader,
+    LomLifecycleItemloader,
+    LomEducationalItemLoader,
+    ValuespaceItemLoader,
+    LicenseItemLoader,
+    ResponseItemLoader,
+    PermissionItemLoader,
+    LomClassificationItemLoader,
+)
+from converter.spiders.base_classes import LomBase
+from converter.web_tools import WebEngine
+
+
+class BnePortalSpider(scrapy.Spider, LomBase):
+    """
+    Crawler for "Lernmaterialien" from BNE-Portal.de. ("Infothek" -> "Lernmaterialien":
+    https://www.bne-portal.de/SiteGlobals/Forms/bne/lernmaterialien/suche_formular.html?nn=140004)
+    """
+
+    name = "bne_portal_spider"
+    friendlyName = "BNE-Portal"
+    version = "0.0.3"  # last update: 2024-08-08
+    playwright_cookies: list[dict] = [
+        {
+            "name": "gsbbanner",
+            "value": "closed"
+        }
+    ]
+    current_session_cookie: dict = dict()
+    # By using two cookie attributes ("gsbbanner" and "AL_SESS-S"), we enable playwright to skip the rendering of
+    # cookie banners while taking website screenshots (e.g., when no thumbnail was provided by BNE).
+    # While we can hard-code the "gsbbanner"-cookie,
+    # we need to dynamically parse the current session cookie ("AL_SESS-S") from the first HTTP response.
+    custom_settings = {
+        "AUTOTHROTTLE_ENABLED": True,
+        "AUTOTHROTTLE_DEBUG": True,
+        # "AUTOTHROTTLE_TARGET_CONCURRENCY": 0.5,
+        "AUTOTHROTTLE_MAX_DELAY": 120,
+        "WEB_TOOLS": WebEngine.Playwright,
+        "ROBOTSTXT_OBEY": False,
+        # "COOKIES_DEBUG": True,
+        "PLAYWRIGHT_COOKIES": playwright_cookies,
+        "PLAYWRIGHT_ADBLOCKER": True,
+        "USER_AGENT": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+    }
+    # NOTICE: Custom Settings
+    # We need to disobey the robots.txt in this case because the crawler would not be able to parse the learning
+    # materials in a timely manner (and requests to the required search form would be disallowed).
+    # We also NEED to spoof the User Agent, because Scrapy Requests without a User Agent always return a "403"-Response.
+
+    # Spider-specific Mappings:
+    # to see a list of possible strings that need to be mapped, check the drop-down menus at:
+    # https://www.bne-portal.de/SiteGlobals/Forms/bne/lernmaterialien/suche_formular.html?nn=140004
+    FORMAT_TO_NEW_LRT: dict = {
+        "Artikel": "b98c0c8c-5696-4537-82fa-dded7236081e",  # Artikel und Einzelpublikation
+        "Broschüre/ Buch/ Zeitschrift": "0cef3ce9-e106-47ae-836a-48f9ed04384e",  # Dokumente und textbasierte Inhalte
+        "Datenbank/ Materialsammlung": "04693b11-8b39-42aa-964f-578be063a851",  # Kollektion, Sammlung oder Kanal
+        "Datenbank-Webseite": "d8c3ef03-b3ab-4a5e-bcc9-5a546fefa2e9",  # Webseite
+        "Digitale Lehr-/ Lerneinheit": ["588efe4f-976f-48eb-84aa-8bcb45679f85", "0d23ff13-9d92-4944-92fa-2b5fe1dde80b"],
+        # Lehr- und Lernmaterial; Stundenentwurf
+        "Film": "7a6e9608-2554-4981-95dc-47ab9ba924de",  # Video (Material)
+        "Poster": "c382a478-74e0-42f1-96dd-fcfb5c27f746",  # Poster und Plakat
+        "Spiel": "b0495f44-b05d-4bde-9dc5-34d7b5234d76",  # Lernspiel
+        "Spiel/ Aktion": "68a43516-889e-4ce9-8e03-248307bd99ff",  # offene und kreative Aktivität
+    }
+
+    BILDUNGSBEREICH_TO_EDUCATIONAL_CONTEXT: dict = {
+        # "bildungsbereichübergreifend": "",  # will be added to keywords due to impossible mapping
+        "Frühkindliche Bildung": "elementarbereich",
+        # "non-formale/ informelle Bildung": "",  # will be added to keywords due to impossible mapping
+        "Primarbereich": "grundschule",
+        "Sekundarbereich I": "sekundarstufe_1",
+        "Sekundarbereich II": "sekundarstufe_2",
+    }
+
+    THEMEN_TO_DISCIPLINE: dict = {
+        "Ernährung": "04006",  # Ernährung und Hauswirtschaft
+        "Gesellschaftslehre": "48005",  # Gesellschaftskunde
+        "Interkulturelles Lernen": "340",  # Interkulturelle Bildung
+    }
+
+    def start_requests(self) -> Iterable[Request]:
+        start_url_lernmaterialien: str = (
+            "https://www.bne-portal.de/SiteGlobals/Forms/bne/lernmaterialien/suche_formular.html"
+        )
+        start_url_publikationen: str = (
+            "https://www.bne-portal.de/SiteGlobals/Forms/bne/publikationen/suche_formular.html?nn=139986"
+        )
+        start_urls: list[str] = [start_url_lernmaterialien, start_url_publikationen]
+        for start_url in start_urls:
+            yield scrapy.Request(
+                url=start_url,
+                callback=self.gather_urls_from_first_page_of_search_results,
+            )
+
+    def gather_urls_from_first_page_of_search_results(self, response: scrapy.http.HtmlResponse, **kwargs):
+        # https://www.bne-portal.de/SiteGlobals/Forms/bne/lernmaterialien/suche_formular.html
+        # at the bottom of the search results should be a page navigation element ("Seite 1 ... X")
+        # we're looking for the last page number to build the list of available URLs
+        last_page_link: str | None = response.xpath("//nav[@class='c-nav-index']/ul/li[last()]/a/@href").get()
+        last_page_number: int | None = None
+        page_number_pattern = re.compile(r"""D(?P<page_number>\d+)#searchResults""")
+        if last_page_link:
+            # the relative URl of the last page currently looks like this:
+            # "SiteGlobals/Forms/bne/lernmaterialien/suche_formular.html?gtp=33528_list%253D59#searchResults"
+            # the page number is controlled via the "D<page_number>#searchResults" part of the URL
+            page_number_result = page_number_pattern.search(string=last_page_link)
+            if page_number_result and "page_number" in page_number_result.groupdict():
+                last_page_str: str = page_number_result.groupdict()["page_number"]
+                last_page_number: int = int(last_page_str)
+        else:
+            self.logger.warning(
+                f"Failed to retrieve last page URL from response {response.url} . "
+                f"Cannot proceed with page iteration. (Please debug the XPath Expression!)"
+            )
+        if last_page_number:
+            overview_relative_url_without_page_param = re.sub(
+                pattern=page_number_pattern, repl="", string=last_page_link
+            )
+            for overview_page_nr in range(2, last_page_number + 1):
+                # since we are already on page 1, we iterate from page 2 to the last page
+                overview_relative_url: str = (
+                    f"{overview_relative_url_without_page_param}" f"D{overview_page_nr}#searchResults"
+                )
+                overview_absolute_url: str = response.urljoin(overview_relative_url)
+                yield scrapy.Request(
+                    url=overview_absolute_url, callback=self.yield_request_for_each_search_result, priority=1
+                )
+        if response.headers and not self.current_session_cookie:
+            # we want to grab the first session cookie exactly ONCE and forward it to playwright,
+            # because it allows us to skip the rendering of the cookie-banner when falling back to website-screenshots
+            self.save_session_cookie_to_spider_custom_settings(response)
+        # the first page should contain 15 search results that need to be yielded to the parse()-method
+        yield from self.yield_request_for_each_search_result(response)
+
+    def save_session_cookie_to_spider_custom_settings(self, response: scrapy.http.HtmlResponse):
+        """
+        Parses the HTML header for a specific cookie attribute ("AL_SESS-S") and saves the key-value pair to the
+        spider's custom_settings.
+        This allows us to skip the rendering of the (obtrusive) cookie banner when a thumbnail was not available,
+        and our pipeline needs to fall back to taking a screenshot with playwright.
+        """
+        cookies_raw: list[bytes] | None = response.headers.getlist("Set-Cookie")
+        if cookies_raw:
+            for cookie_bytes_object in cookies_raw:
+                if cookie_bytes_object and isinstance(cookie_bytes_object, bytes):
+                    # cookie example:
+                    # b'AL_SESS-S=AVHw!yeRm5uXQNxe3FM!nbN33IjG7EMgCO2CipHfxK1Iv34ESuTGarlWWhYFBecs0e3b;
+                    # Path=/; Secure; HttpOnly; SameSite=Lax'
+                    cookie = cookie_bytes_object.decode("utf-8")
+                    # we need to decode the cookie into a string object first
+                    if "AL_SESS-S" in cookie:
+                        # we want to pass the session cookie to playwright, in order to not rely on hard-coding a
+                        # session cookie (which might become invalid at any future moment).
+                        cookie_attributes: list[str] | None = cookie.split(";")
+                        # first, we need to split the cookie bytes object into the individual cookie attributes
+                        if cookie_attributes:
+                            for cookie_attribute in cookie_attributes:
+                                if "AL_SESS-S=" in cookie_attribute:
+                                    # We're only interested in the session cookie. The other attributes don't seem
+                                    # to be necessary to skip the cookie-banner
+                                    cookie_split = cookie_attribute.split("=")
+                                    cookie_name: str = cookie_split[0]
+                                    cookie_value: str = cookie_split[1]
+                                    session_cookie = {"name": cookie_name, "value": cookie_value}
+                                    self.current_session_cookie.update(session_cookie)
+            if self.current_session_cookie:
+                self.logger.info(
+                    f"Saving current session cookie to 'PLAYWRIGHT_COOKIES'-custom-settings. "
+                    f"Session cookie: {self.current_session_cookie}"
+                )
+                # we expect the current sesison cookie to look like this:
+                # {
+                #     "name": "AL_SESS-S",
+                #     "value": "AUiJVd4i8sXlsq6ZEHfjlvfvCBhnub4_TNyxnydq1cpcuRk8EvO5ryyD9643seQ742AB",
+                # },
+                self.playwright_cookies.append(self.current_session_cookie)
+                self.custom_settings.update({"PLAYWRIGHT_COOKIES": self.playwright_cookies})
+
+    def yield_request_for_each_search_result(self, response: scrapy.http.HtmlResponse):
+        search_result_relative_urls: list[str] = response.xpath(
+            "//div[@class='c-pub-teaser__text-wrapper']/h2/a[@class='c-pub-teaser__title-link']/@href"
+        ).getall()
+        if search_result_relative_urls and isinstance(search_result_relative_urls, list):
+            self.logger.debug(f"Detected {len(search_result_relative_urls)} search results on {response.url}")
+            for url_item in search_result_relative_urls:
+                search_result_absolute_url: str = response.urljoin(url_item)
+                yield scrapy.Request(url=search_result_absolute_url, callback=self.parse)
+
+    @staticmethod
+    def clean_up_and_split_list_of_strings(raw_list_of_strings: list[str]):
+        """
+        Cleans up a (raw) list of strings by
+        1) removing whitespace chars from the beginning / end of strings
+        2) removing empty strings (that only consist of newlines / whitespaces)
+        3) splitting multiple string values (which are separated by comma on BNE-Portal) into individual strings
+        and returns the result as a list[str] if successful.
+
+        @param raw_list_of_strings: a list of strings that might contain unnecessary whitespace chars or empty strings
+        @return: cleaned up list[str] if successful, otherwise None.
+        """
+        temporary_list_of_strings: list[str] = list()
+        clean_list_of_strings: list[str] = list()
+        if raw_list_of_strings and isinstance(raw_list_of_strings, list):
+            for raw_string in raw_list_of_strings:
+                if isinstance(raw_string, str):
+                    cleaned_string: str | None = raw_string.strip()
+                    if cleaned_string:
+                        temporary_list_of_strings.append(cleaned_string)
+        if temporary_list_of_strings:
+            for temp_str in temporary_list_of_strings:
+                if ", " in temp_str:
+                    individual_strings: list[str] = temp_str.split(", ")
+                    if individual_strings:
+                        clean_list_of_strings.extend(individual_strings)
+                else:
+                    clean_list_of_strings.append(temp_str)
+        if clean_list_of_strings:
+            return clean_list_of_strings
+        else:
+            return None
+
+    def getId(self, response=None) -> str:
+        # BNE-Portal.de does not provide an identifier for their items, therefore we resort to the URL
+        return response.url
+
+    def getHash(self, response=None) -> str:
+        # BNE-Portal.de does not provide a publication or modification date,
+        # therefore we need to resort to the timestamp of the crawl
+        now = datetime.datetime.now().isoformat()
+        hash_str: str = f"{now}v{self.version}"
+        return hash_str
+
+    def parse(self, response=None, **kwargs):
+        trafilatura_text: str | None = trafilatura.extract(response.body)
+
+        if self.shouldImport(response) is False:
+            self.logger.debug(f"Skipping entry {self.getId(response)} because shouldImport() returned False")
+            return None
+        if self.getId(response) is not None and self.getHash(response) is not None:
+            if not self.hasChanged(response):
+                return None
+
+        # Metadata (Header)
+        title: str | None = response.xpath("//meta[@name='title']/@content").get()
+        og_title: str = response.xpath("//meta[@property='og:title']/@content").get()
+        description: str | None = response.xpath("//meta[@name='description']/@content").get()
+        og_description: str | None = response.xpath("//meta[@property='og:description']/@content").get()
+
+        keywords_from_header: str | None = response.xpath("//meta[@name='keywords']/@content").get()
+        keyword_set: set[str] = set()
+        if keywords_from_header and isinstance(keywords_from_header, str) and ", " in keywords_from_header:
+            # keyword values are typically split by comma in the DOM header
+            keyword_list: list[str] = keywords_from_header.split(", ")
+            if keyword_list:
+                keyword_set.update(keyword_list)
+        elif keywords_from_header and isinstance(keywords_from_header, str):
+            # this case should only happen if there is only a single keyword available in the header
+            keyword_set.add(keywords_from_header)
+
+        # og_type: str | None = response.xpath("//meta[@property='og:type']/@content").get()
+        og_image: str | None = response.xpath("//meta[@property='og:image']/@content").get()
+        # attention: a big amount of (older) learning materials do not have a thumbnail!
+        # og_image_type: str | None = response.xpath("//meta[@property='og:image:type']/@content").get()
+        og_locale: str | None = response.xpath("//meta[@property='og:locale']/@content").get()
+        og_url: str | None = response.xpath("//meta[@property='og:url']/@content").get()
+
+        # metadata (DOM)
+        #  - optional: "Mehr Informationen" should contain the URL to source website
+        bne_format_raw: list[str] | None = response.xpath("//strong[contains(text(),'Format')]/../text()").getall()
+        # this XPath Expression looks for the bold text "Format", which shares the same <p>-element as the desired
+        # strings. Therefore, we select its parent with ".." and grab all text strings for further metadata extraction.
+        bne_thema_raw: list[str] | None = response.xpath("//strong[contains(text(),'Thema')]/../text()").getall()
+        bne_bildungsbereich_raw: list[str] | None = response.xpath(
+            "//strong[contains(text(),'Bildungsbereich')]/../text()"
+        ).getall()
+        bne_kosten_raw: list[str] | None = response.xpath("//strong[contains(text(),'Kosten')]/../text()").getall()
+
+        bne_format_clean: list[str] | None = self.clean_up_and_split_list_of_strings(bne_format_raw)
+        bne_thema_clean: list[str] | None = self.clean_up_and_split_list_of_strings(bne_thema_raw)
+        bne_bildungsbereich_clean: list[str] | None = self.clean_up_and_split_list_of_strings(bne_bildungsbereich_raw)
+        bne_kosten_clean: list[str] | None = self.clean_up_and_split_list_of_strings(bne_kosten_raw)
+
+        bne_guetesiegel: list | None = response.xpath("//div[@class='c-pub-teaser__stamp']").getall()
+        # the "BNE Gütesiegel" is displayed at the bottom right of curated materials.
+        # (as of 2024-08-02 there are 6 of those materials in total)
+        # If this <div>-container shows up, we'll add the "erfüllt BNE-Gütekriterien" keyword to our list.
+        if bne_guetesiegel:
+            keyword_set.add("erfüllt BNE-Gütekriterien")
+
+        new_lrt_set: set[str] = set()
+        if bne_format_clean and isinstance(bne_format_clean, list):
+            for format_str in bne_format_clean:
+                if format_str in self.FORMAT_TO_NEW_LRT:
+                    # manually mapping BNE "Format"-strings (e.g. 'Film', 'Poster') to our new_lrt Vocab for those cases
+                    # where the raw strings would not match with our vocab
+                    new_lrt_mapped: list[str] | str = self.FORMAT_TO_NEW_LRT.get(format_str)
+                    if isinstance(new_lrt_mapped, str):
+                        new_lrt_set.add(new_lrt_mapped)
+                    if isinstance(new_lrt_mapped, list):
+                        for mapped_value in new_lrt_mapped:
+                            new_lrt_set.add(mapped_value)
+                elif format_str:
+                    # this case typically happens for perfect matches (e.g. "Arbeitsblatt") or uncovered edge-cases
+                    new_lrt_set.add(format_str)
+
+        if "/Publikationen/" in response.url:
+            new_lrt_set.add("b98c0c8c-5696-4537-82fa-dded7236081e")  # Artikel und Einzelpublikation
+
+        disciplines: set[str] = set()
+        if bne_thema_clean and isinstance(bne_thema_clean, list):
+            for thema_str in bne_thema_clean:
+                if thema_str in self.THEMEN_TO_DISCIPLINE:
+                    thema_mapped: str = self.THEMEN_TO_DISCIPLINE.get(thema_str)
+                    disciplines.add(thema_mapped)
+                elif thema_str:
+                    # at this point we cannot know if the "Thema"-string is a discipline or not, therefore we treat it
+                    # as additional keywords because the majority of values that we receive from "Thema" are keywords.
+                    disciplines.add(thema_str)
+                    keyword_set.add(thema_str)
+
+        educational_context_set: set[str] = set()
+        if bne_bildungsbereich_clean and isinstance(bne_bildungsbereich_clean, list):
+            # Mapping BNE "Bildungsbereich" values to educationalContext
+            for bb_str in bne_bildungsbereich_clean:
+                if bb_str in self.BILDUNGSBEREICH_TO_EDUCATIONAL_CONTEXT:
+                    bb_mapped: str = self.BILDUNGSBEREICH_TO_EDUCATIONAL_CONTEXT.get(bb_str)
+                    educational_context_set.add(bb_mapped)
+                elif bb_str:
+                    educational_context_set.add(bb_str)
+                    if "bildungsbereichübergreifend" in bb_str or "non-formale/ informelle Bildung" in bb_str:
+                        # these two edge-cases can't be mapped to educationalContext. To not lose out on these values,
+                        # we save them to the keywords instead.
+                        keyword_set.add(bb_str)
+
+        price: str | None = None
+        if bne_kosten_clean and isinstance(bne_kosten_clean, list):
+            # there should be exactly 1 string value in this list by now
+            if len(bne_kosten_clean) == 1:
+                for cost_str in bne_kosten_clean:
+                    if cost_str and isinstance(cost_str, str):
+                        cost_str: str = cost_str.lower()
+                        if "kostenfrei" in cost_str:
+                            price = "no"
+                            pass
+                        elif "kostenpflichtig" in cost_str:
+                            price = "yes"
+                        elif "€" in cost_str:
+                            # there is currently (as of 2024-08-01) one single item that has an actual price string.
+                            # example:
+                            # https://www.bne-portal.de/bne/shareddocs/lernmaterialien/de/praxisbuch-mobilitaetsbildung.html#searchFacets
+                            price = "yes"
+                        elif "null" in cost_str:
+                            # observed 5 edge-cases where free materials carried the "Kosten"-string: "null"
+                            # this might be a typo in their CMS, but handling these edge-cases as free seems reasonable.
+                            # example:
+                            # https://www.bne-portal.de/bne/shareddocs/lernmaterialien/de/nachhaltige-stadtentwicklung.html#searchFacets
+                            price = "no"
+                        else:
+                            self.logger.warning(
+                                f"Failed to map BNE 'Kosten'-value to 'price'-vocab. Please update the mapping "
+                                f"for this edge-case: '{cost_str}'"
+                            )
+            else:
+                # if BNE-Portal starts using more than two values in the future, we need to update our mapping
+                self.logger.warning(
+                    f"Mapping edge-case for BNE 'Kosten' detected: Expected exactly 1 value in "
+                    f"{bne_kosten_clean}, but received {len(bne_kosten_clean)}. "
+                    f"Values received: {bne_kosten_clean}"
+                )
+
+        base_itemloader: BaseItemLoader = BaseItemLoader()
+        base_itemloader.add_value("sourceId", self.getId(response))
+        base_itemloader.add_value("hash", self.getHash(response))
+        if og_image:
+            base_itemloader.add_value("thumbnail", og_image)
+        if trafilatura_text:
+            base_itemloader.add_value("fulltext", trafilatura_text)
+
+        lom_base_itemloader: LomBaseItemloader = LomBaseItemloader()
+
+        lom_classification_itemloader: LomClassificationItemLoader = LomClassificationItemLoader()
+
+        lom_general_itemloader: LomGeneralItemloader = LomGeneralItemloader()
+        lom_general_itemloader.add_value("identifier", response.url)
+        if title:
+            lom_general_itemloader.add_value("title", title)
+        elif og_title:
+            lom_general_itemloader.add_value("title", og_title)
+        if description:
+            lom_general_itemloader.add_value("description", description)
+        elif og_description:
+            lom_general_itemloader.add_value("description", og_description)
+        if og_locale:
+            lom_general_itemloader.add_value("language", og_locale)
+        if keyword_set:
+            keyword_list = list(keyword_set)
+            lom_general_itemloader.add_value("keyword", keyword_list)
+
+        lom_educational_itemloader: LomEducationalItemLoader = LomEducationalItemLoader()
+
+        lom_technical_itemloader: LomTechnicalItemLoader = LomTechnicalItemLoader()
+        if og_url and og_url != response.url:
+            lom_technical_itemloader.add_value("location", og_url)
+            lom_technical_itemloader.add_value("location", response.url)
+        else:
+            lom_technical_itemloader.add_value("location", response.url)
+        lom_technical_itemloader.add_value("format", "text/html")
+
+        lom_lifecycle_itemloader: LomLifecycleItemloader = LomLifecycleItemloader()
+        lom_lifecycle_itemloader.add_value("role", "publisher")
+        lom_lifecycle_itemloader.add_value("organization", "Bundesministerium für Bildung und Forschung")
+        lom_lifecycle_itemloader.add_value(
+            "url", "https://www.bne-portal.de/bne/de/services/impressum/impressum_node.html"
+        )
+        lom_base_itemloader.add_value("lifecycle", lom_lifecycle_itemloader.load_item())
+
+        license_itemloader: LicenseItemLoader = LicenseItemLoader()
+        license_itemloader.add_value("author", "Bundesministerium für Bildung und Forschung")
+        license_itemloader.add_value("internal", Constants.LICENSE_COPYRIGHT_FREE)
+        license_description: str = (
+            "Das Copyright für Texte liegt, soweit nicht anders vermerkt, "
+            "beim Bundesministerium für Bildung und Forschung (nachfolgend BMBF). Das "
+            "Copyright für Bilder liegt, soweit nicht anders vermerkt, beim Bundesministerium "
+            "für Bildung und Forschung oder bei der Bundesbildstelle des Presse- und "
+            "Informationsamtes der Bundesregierung. Auf den BMBF-Webseiten zur Verfügung "
+            "gestellte Texte, Textteile, Grafiken, Tabellen oder Bildmaterialien dürfen ohne "
+            "vorherige Zustimmung des BMBF nicht vervielfältigt, nicht verbreitet und nicht "
+            "ausgestellt werden."
+        )
+        # see: https://www.bne-portal.de/bne/de/services/impressum/impressum_node.html
+        license_itemloader.add_value("description", license_description)
+
+        permission_itemloader: PermissionItemLoader = self.getPermissions(response=response)
+
+        valuespace_itemloader: ValuespaceItemLoader = ValuespaceItemLoader()
+        valuespace_itemloader.add_value("new_lrt", Constants.NEW_LRT_MATERIAL)
+        disciplines.add("64018")  # Nachhaltigkeit is hard-coded for all BNE materials
+        if disciplines:
+            discipline_list: list[str] = list(disciplines)
+            valuespace_itemloader.add_value("discipline", discipline_list)
+        if educational_context_set:
+            edu_context_list: list[str] = list(educational_context_set)
+            valuespace_itemloader.add_value("educationalContext", edu_context_list)
+        if new_lrt_set:
+            new_lrt_list: list[str] = list(new_lrt_set)
+            valuespace_itemloader.add_value("new_lrt", new_lrt_list)
+        if price:
+            valuespace_itemloader.add_value("price", price)
+
+        response_itemloader: ResponseItemLoader = ResponseItemLoader()
+        response_itemloader.add_value("headers", response.headers)
+        response_itemloader.add_value("status", response.status)
+        response_itemloader.add_value("text", trafilatura_text)
+        response_itemloader.add_value("url", response.url)
+
+        lom_base_itemloader.add_value("classification", lom_classification_itemloader.load_item())
+        lom_base_itemloader.add_value("educational", lom_educational_itemloader.load_item())
+        lom_base_itemloader.add_value("general", lom_general_itemloader.load_item())
+        lom_base_itemloader.add_value("technical", lom_technical_itemloader.load_item())
+
+        base_itemloader.add_value("lom", lom_base_itemloader.load_item())
+        base_itemloader.add_value("license", license_itemloader.load_item())
+        base_itemloader.add_value("valuespaces", valuespace_itemloader.load_item())
+        base_itemloader.add_value("permissions", permission_itemloader.load_item())
+        base_itemloader.add_value("response", response_itemloader.load_item())
+        yield base_itemloader.load_item()

--- a/converter/spiders/oersi_spider.py
+++ b/converter/spiders/oersi_spider.py
@@ -41,7 +41,7 @@ class OersiSpider(scrapy.Spider, LomBase):
     name = "oersi_spider"
     # start_urls = ["https://oersi.org/"]
     friendlyName = "OERSI"
-    version = "0.2.6"  # last update: 2024-05-28
+    version = "0.2.7"  # last update: 2024-07-30
     custom_settings = {
         "AUTOTHROTTLE_ENABLED": True,
         "AUTOTHROTTLE_DEBUG": True,
@@ -199,8 +199,8 @@ class OersiSpider(scrapy.Spider, LomBase):
                 )
                 return None
             if (
-                    self.getId(response=None, elastic_item=elastic_item) is not None
-                    and self.getHash(response=None, elastic_item_source=elastic_item["_source"]) is not None
+                self.getId(response=None, elastic_item=elastic_item) is not None
+                and self.getHash(response=None, elastic_item_source=elastic_item["_source"]) is not None
             ):
                 if not self.hasChanged(None, elastic_item=elastic_item):
                     return None
@@ -509,12 +509,12 @@ class OersiSpider(scrapy.Spider, LomBase):
         return changed
 
     def get_lifecycle_author(
-            self,
-            lom_base_item_loader: LomBaseItemloader,
-            elastic_item_source: dict,
-            organization_fallback: set[str],
-            date_created: Optional[str] = None,
-            date_published: Optional[str] = None,
+        self,
+        lom_base_item_loader: LomBaseItemloader,
+        elastic_item_source: dict,
+        organization_fallback: set[str],
+        date_created: Optional[str] = None,
+        date_published: Optional[str] = None,
     ):
         """
         If a "creator"-field is available in the OERSI API for a specific '_source'-item, creates an 'author'-specific
@@ -582,11 +582,11 @@ class OersiSpider(scrapy.Spider, LomBase):
         return authors
 
     def get_affiliation_and_save_to_lifecycle(
-            self,
-            affiliation_dict: dict,
-            lom_base_item_loader: LomBaseItemloader,
-            organization_fallback: set[str],
-            lifecycle_role: str,
+        self,
+        affiliation_dict: dict,
+        lom_base_item_loader: LomBaseItemloader,
+        organization_fallback: set[str],
+        lifecycle_role: str,
     ):
         """
         Retrieves metadata from OERSI's "affiliation"-field (which is typically found within a "creator"- or
@@ -650,11 +650,11 @@ class OersiSpider(scrapy.Spider, LomBase):
         return honorific_prefix.strip()
 
     def get_lifecycle_contributor(
-            self,
-            lom_base_item_loader: LomBaseItemloader,
-            elastic_item_source: dict,
-            organization_fallback: set[str],
-            author_list: Optional[list[str]] = None,
+        self,
+        lom_base_item_loader: LomBaseItemloader,
+        elastic_item_source: dict,
+        organization_fallback: set[str],
+        author_list: Optional[list[str]] = None,
     ):
         """
         Collects metadata from the OERSI "contributor"-field and stores it within a LomLifecycleItemLoader.
@@ -756,11 +756,11 @@ class OersiSpider(scrapy.Spider, LomBase):
             lom_base_item_loader.add_value("lifecycle", lifecycle_metadata_provider.load_item())
 
     def get_lifecycle_publisher(
-            self,
-            lom_base_item_loader: LomBaseItemloader,
-            elastic_item_source: dict,
-            organizations_from_publisher_fields: set[str],
-            date_published: Optional[str] = None,
+        self,
+        lom_base_item_loader: LomBaseItemloader,
+        elastic_item_source: dict,
+        organizations_from_publisher_fields: set[str],
+        date_published: Optional[str] = None,
     ):
         """
         Collects metadata from OERSI's "publisher"-field and stores it within a LomLifecycleItemLoader. Successfully
@@ -796,7 +796,7 @@ class OersiSpider(scrapy.Spider, LomBase):
                     lom_base_item_loader.add_value("lifecycle", lifecycle_publisher.load_item())
 
     def get_lifecycle_organization_from_source_organization_fallback(
-            self, elastic_item_source: dict, lom_item_loader: LomBaseItemloader, organization_fallback: set[str]
+        self, elastic_item_source: dict, lom_item_loader: LomBaseItemloader, organization_fallback: set[str]
     ):
         # ATTENTION: the "sourceOrganization"-field is not part of the AMB draft, therefore this method is currently
         # used a fallback, so we don't lose any useful metadata (even if that metadata is not part of the AMB spec).
@@ -838,8 +838,7 @@ class OersiSpider(scrapy.Spider, LomBase):
                 lom_item_loader.add_value("lifecycle", lifecycle_org.load_item())
 
     def get_lifecycle_publisher_from_source_organization(
-            self, lom_item_loader: LomBaseItemloader, elastic_item_source: dict,
-            previously_collected_publishers: set[str]
+        self, lom_item_loader: LomBaseItemloader, elastic_item_source: dict, previously_collected_publishers: set[str]
     ):
         source_organizations: list[dict] = elastic_item_source.get("sourceOrganization")
         for so in source_organizations:
@@ -860,7 +859,7 @@ class OersiSpider(scrapy.Spider, LomBase):
                     lom_item_loader.add_value("lifecycle", lifecycle_org.load_item())
 
     def lifecycle_determine_type_of_identifier_and_save_uri(
-            self, item_dictionary: dict, lifecycle_item_loader: LomLifecycleItemloader
+        self, item_dictionary: dict, lifecycle_item_loader: LomLifecycleItemloader
     ):
         """
         OERSI's "creator"/"contributor"/"affiliation" items might contain an 'id'-field which (optionally) provides
@@ -873,10 +872,10 @@ class OersiSpider(scrapy.Spider, LomBase):
             # "creator.id" can be 'null', therefore we need to explicitly check its type before trying to parse it
             uri_string: str = item_dictionary.get("id")
             if (
-                    "orcid.org" in uri_string
-                    or "/gnd/" in uri_string
-                    or "wikidata.org" in uri_string
-                    or "ror.org" in uri_string
+                "orcid.org" in uri_string
+                or "/gnd/" in uri_string
+                or "wikidata.org" in uri_string
+                or "ror.org" in uri_string
             ):
                 if "/gnd/" in uri_string:
                     lifecycle_item_loader.add_value("id_gnd", uri_string)
@@ -953,8 +952,9 @@ class OersiSpider(scrapy.Spider, LomBase):
                                         course_itemloader.add_value("course_availability_from", start_date_raw)
                                     else:
                                         self.logger.warning(
-                                            f"Received unexpected type for \"startDate\" {start_date_raw} . "
-                                            f"Expected str, but received {type(start_date_raw)} instead.")
+                                            f'Received unexpected type for "startDate" {start_date_raw} . '
+                                            f"Expected str, but received {type(start_date_raw)} instead."
+                                        )
                         if "endDate" in imoox_attributes:
                             end_dates: list[str] = imoox_attributes["endDate"]
                             if end_dates and isinstance(end_dates, list):
@@ -963,7 +963,7 @@ class OersiSpider(scrapy.Spider, LomBase):
                                         course_itemloader.add_value("course_availability_until", end_date_raw)
                                     else:
                                         self.logger.warning(
-                                            f"Received unexpected type for \"endDate\" {end_date_raw}. "
+                                            f'Received unexpected type for "endDate" {end_date_raw}. '
                                             f"Expected str, but received {type(end_date_raw)} instead."
                                         )
                         if "trailer" in imoox_attributes:
@@ -1049,11 +1049,11 @@ class OersiSpider(scrapy.Spider, LomBase):
                     base_itemloader.add_value("course", course_itemloader.load_item())
 
     def enrich_vhb_metadata(
-            self,
-            base_itemloader: BaseItemLoader,
-            elastic_item: dict,
-            lom_general_itemloader: LomGeneralItemloader,
-            in_languages: list[str] | None,
+        self,
+        base_itemloader: BaseItemLoader,
+        elastic_item: dict,
+        lom_general_itemloader: LomGeneralItemloader,
+        in_languages: list[str] | None,
     ):
         """
         Combines metadata from OERSI's elastic_item with MOOCHub v2.x metadata from the source (vhb)
@@ -1117,9 +1117,10 @@ class OersiSpider(scrapy.Spider, LomBase):
                             if start_date_raw and isinstance(start_date_raw, str):
                                 course_itemloader.add_value("course_availability_from", start_date_raw)
                             else:
-                                self.logger.warning(f"Received unexpected type for \"startDate\" {start_date_raw} . "
-                                                    f"Expected a string, but received {type(start_date_raw)} instead."
-                                                    )
+                                self.logger.warning(
+                                    f'Received unexpected type for "startDate" {start_date_raw} . '
+                                    f"Expected a string, but received {type(start_date_raw)} instead."
+                                )
                         if "video" in vhb_item_matched["attributes"]:
                             video_item: dict = vhb_item_matched["attributes"]["video"]
                             if video_item:
@@ -1175,7 +1176,7 @@ class OersiSpider(scrapy.Spider, LomBase):
                                                     # timedelta has no parameter for months
                                                     #  -> X months = X * (4 weeks)
                                                     duration_delta = duration_delta + (
-                                                            duration_number * datetime.timedelta(weeks=4)
+                                                        duration_number * datetime.timedelta(weeks=4)
                                                     )
                                                 case _:
                                                     self.logger.warning(
@@ -1188,6 +1189,211 @@ class OersiSpider(scrapy.Spider, LomBase):
                                                 if workload_in_seconds:
                                                     course_itemloader.add_value("course_duration", workload_in_seconds)
                     base_itemloader.add_value("course", course_itemloader.load_item())
+
+    def look_for_twillo_url_in_elastic_item(self, elastic_item: dict) -> str | None:
+        """
+        Look for a twillo.de URL with an "/edu-sharing/"-path within OERSI's "_source.id" and "mainEntityOfPage.id"
+        properties.
+        Returns the twillo URL string if successful, otherwise returns None.
+        """
+        twillo_url: str | None = None
+        twillo_url_from_source_id: str = self.getId(response=None, elastic_item=elastic_item)
+        twillo_url_from_maeop_id: str | None = None
+        twillo_edu_sharing_url_path: str = "twillo.de/edu-sharing/components/render/"
+        if "_source" in elastic_item:
+            elastic_item_source: dict = elastic_item["_source"]
+            if "mainEntityOfPage" in elastic_item_source:
+                main_entity_of_page: list[dict] = elastic_item_source["mainEntityOfPage"]
+                for maeop_item in main_entity_of_page:
+                    if "id" in maeop_item:
+                        maeop_id: str = maeop_item["id"]
+                        if maeop_id and twillo_edu_sharing_url_path in maeop_id:
+                            twillo_url_from_maeop_id = maeop_id
+        if twillo_url_from_source_id and twillo_edu_sharing_url_path in twillo_url_from_source_id:
+            twillo_url = twillo_url_from_source_id
+        elif twillo_url_from_maeop_id:
+            twillo_url = twillo_url_from_maeop_id
+        return twillo_url
+
+    @staticmethod
+    def extract_twillo_node_id_from_url(twillo_url: str) -> str | None:
+        """
+        Extract the twillo nodeId from a provided URL string.
+        """
+        if twillo_url and isinstance(twillo_url, str):
+            twillo_node_id: str | None = None
+            if "twillo.de/edu-sharing/components/render/" in twillo_url:
+                potential_twillo_node_id = twillo_url.split("/")[-1]
+                if potential_twillo_node_id and isinstance(potential_twillo_node_id, str):
+                    twillo_node_id = potential_twillo_node_id
+            if twillo_node_id:
+                return twillo_node_id
+            else:
+                return None
+
+    def request_metadata_for_twillo_node_id(
+        self,
+        base_itemloader: BaseItemLoader,
+        lom_base_itemloader: LomBaseItemloader,
+        lom_classification_itemloader: LomClassificationItemLoader,
+        lom_educational_itemloader: LomEducationalItemLoader,
+        lom_general_itemloader: LomGeneralItemloader,
+        lom_technical_itemloader: LomTechnicalItemLoader,
+        license_itemloader: LicenseItemLoader,
+        valuespaces_itemloader: ValuespaceItemLoader,
+        elastic_item: dict,
+        twillo_node_id: str,
+    ):
+        """
+        Query the edu-sharing repository of twillo.de for metadata of a specific nodeId.
+        If the request was successful, return the response dictionary.
+        """
+        twillo_api_request_url = (
+            f"https://www.twillo.de/edu-sharing/rest/rendering/v1/details/-home-/" f"{twillo_node_id}"
+        )
+        # note: we NEED to use the "rendering/v1/details/..."-API-endpoint because
+        # https://www.twillo.de/edu-sharing/rest/node/v1/nodes/-home-/{twillo_node_id}/metadata?propertyFilter=-all-
+        # throws "org.edu_sharing.restservices.DAOSecurityException"-errors (for hundreds of objects!),
+        # even though the queried learning objects are publicly available and reachable
+        twillo_request = scrapy.Request(
+            url=twillo_api_request_url,
+            priority=2,
+            callback=self.enrich_oersi_item_with_twillo_metadata,
+            cb_kwargs={
+                "elastic_item": elastic_item,
+                "twillo_node_id": twillo_node_id,
+                "base_itemloader": base_itemloader,
+                "lom_base_itemloader": lom_base_itemloader,
+                "lom_classification_itemloader": lom_classification_itemloader,
+                "lom_educational_itemloader": lom_educational_itemloader,
+                "lom_general_itemloader": lom_general_itemloader,
+                "lom_technical_itemloader": lom_technical_itemloader,
+                "license_itemloader": license_itemloader,
+                "valuespaces_itemloader": valuespaces_itemloader,
+            },
+        )
+        yield twillo_request
+
+    def enrich_oersi_item_with_twillo_metadata(
+        self,
+        response: scrapy.http.TextResponse,
+        base_itemloader: BaseItemLoader,
+        lom_base_itemloader: LomBaseItemloader,
+        lom_classification_itemloader: LomClassificationItemLoader,
+        lom_educational_itemloader: LomEducationalItemLoader,
+        lom_general_itemloader: LomGeneralItemloader,
+        lom_technical_itemloader: LomTechnicalItemLoader,
+        license_itemloader: LicenseItemLoader,
+        valuespaces_itemloader: ValuespaceItemLoader,
+        elastic_item: dict = None,
+        twillo_node_id: str = None,
+    ):
+        """
+        Process the twillo API response and enrich the OERSI item with twillo metadata properties (if possible).
+        If the twillo API response was invalid (or didn't provide the metadata we were looking for), yield the
+        (complete) BaseItem.
+
+        @param response: the twillo API response (JSON)
+        @param base_itemloader: BaseItemLoader object
+        @param lom_base_itemloader: LomBaseItemloader object
+        @param lom_classification_itemloader: LomClassificationItemloader object
+        @param lom_educational_itemloader: LomEducationalItemloader object
+        @param lom_general_itemloader: LomGeneralItemloader object
+        @param lom_technical_itemloader: LomTechnicalItemloader object
+        @param license_itemloader: LicenseItemloader object
+        @param valuespaces_itemloader: ValuespacesItemloader object
+        @param elastic_item: the ElasticSearch item from the OERSI API
+        @param twillo_node_id: the twillo "nodeId"
+        @return: the complete BaseItem object
+        """
+        twillo_response: scrapy.http.TextResponse = response
+        twillo_response_json: dict | None = None
+        twillo_metadata: dict | None = None
+        try:
+            twillo_response_json: dict = twillo_response.json()
+        except requests.exceptions.JSONDecodeError:
+            self.logger.warning(f"BIRD: Received invalid JSON response from {response.url} :" f"{twillo_response}")
+        if twillo_response_json and isinstance(twillo_response_json, dict):
+            if "node" in twillo_response_json:
+                # we assume that the response is valid if we receive a dictionary containing
+                # "node" as the main key
+                twillo_metadata = twillo_response_json
+            else:
+                self.logger.warning(
+                    f"BIRD: twillo API response for nodeId {twillo_node_id} " f"was invalid: {twillo_response_json}"
+                )
+        else:
+            self.logger.warning(
+                f"BIRD: Failed to extract additional metadata for twillo "
+                f"nodeId {twillo_node_id} ! "
+                f"Received HTTP Response Status {twillo_response.status}."
+            )
+
+        if twillo_metadata and isinstance(twillo_metadata, dict):
+            # the API response should contain a "node"-key which contains all properties within
+            node_dict: dict = twillo_metadata["node"]
+            if node_dict and "properties" in node_dict:
+                node_properties: dict = node_dict["properties"]
+                if node_properties:
+                    twillo_typical_learning_time: list[str] | None = None
+                    twillo_cclom_context: list[str] | None = None
+                    # ToDo:
+                    #  - twillo "Level" ("cclom:interactivitylevel") -> BIRD <?>
+                    #  - twillo "Event Format" ("cclom:interactivitytype") -> BIRD <?>
+                    #  - twillo "Technical Requirements" ("cclom:otherplatformrequirements") -> BIRD <?>
+                    if "cclom:typicallearningtime" in node_properties:
+                        # twillo "Duration" ("cclom:typicallearningtime") -> BIRD "course_duration"
+                        twillo_typical_learning_time: list[str] = node_properties["cclom:typicallearningtime"]
+                    if "cclom:context" in node_properties:
+                        # twillo "Function" ("cclom:context") -> BIRD "course_learningoutcome"
+                        twillo_cclom_context: list[str] = node_properties["cclom:context"]
+                    if "cclom:educational_description" in node_properties:
+                        educational_description_raw: list[str] = node_properties["cclom:educational_description"]
+                        if educational_description_raw and isinstance(educational_description_raw, list):
+                            # twillo Frontend: "Field Report" (= "cclom:educational_description")
+                            for edu_desc_item in educational_description_raw:
+                                if edu_desc_item and isinstance(edu_desc_item, str):
+                                    # strip whitespace and sort out the invalid (empty) strings first
+                                    edu_desc_item: str = edu_desc_item.strip()
+                                    # ToDo: move responsibility of cleaning up "description"-strings
+                                    #  into its own pipeline
+                                    if edu_desc_item:
+                                        lom_educational_itemloader.add_value("description", edu_desc_item)
+                    if twillo_typical_learning_time or twillo_cclom_context:
+                        course_item_loader = CourseItemLoader()
+                        if twillo_typical_learning_time:
+                            course_item_loader.add_value("course_duration", twillo_typical_learning_time)
+                        if twillo_cclom_context:
+                            context_cleaned: list[str] = list()
+                            if twillo_cclom_context and isinstance(twillo_cclom_context, list):
+                                for context_value in twillo_cclom_context:
+                                    if context_value and isinstance(context_value, str):
+                                        context_value = context_value.strip()
+                                        # whitespace typos and empty string values (" ") are removed
+                                        if context_value:
+                                            context_cleaned.append(context_value)
+                            if context_cleaned:
+                                course_item_loader.add_value("course_learningoutcome", context_cleaned)
+                        base_itemloader.add_value("course", course_item_loader.load_item())
+
+        # noinspection DuplicatedCode
+        lom_base_itemloader.add_value("general", lom_general_itemloader.load_item())
+        lom_base_itemloader.add_value("technical", lom_technical_itemloader.load_item())
+        lom_base_itemloader.add_value("educational", lom_educational_itemloader.load_item())
+        lom_base_itemloader.add_value("classification", lom_classification_itemloader.load_item())
+        base_itemloader.add_value("lom", lom_base_itemloader.load_item())
+        base_itemloader.add_value("valuespaces", valuespaces_itemloader.load_item())
+        base_itemloader.add_value("license", license_itemloader.load_item())
+
+        permissions = super().getPermissions(response)
+        base_itemloader.add_value("permissions", permissions.load_item())
+
+        response_loader = ResponseItemLoader()
+        identifier_url: str = self.get_item_url(elastic_item=elastic_item)
+        response_loader.add_value("url", identifier_url)
+        base_itemloader.add_value("response", response_loader.load_item())
+
+        yield base_itemloader.load_item()
 
     def parse(self, response=None, **kwargs):
         elastic_item: dict = kwargs.get("elastic_item")
@@ -1518,6 +1724,27 @@ class OersiSpider(scrapy.Spider, LomBase):
                 if query_parameter_provider_name:
                     if query_parameter_provider_name == "iMoox":
                         self.enrich_imoox_metadata(base, elastic_item)
+                    if query_parameter_provider_name == "twillo":
+                        twillo_url: str | None = self.look_for_twillo_url_in_elastic_item(elastic_item)
+                        # a typical twillo URL could look like this example:
+                        # https://www.twillo.de/edu-sharing/components/render/106ed8e7-1d07-4a77-8ca2-19c9e28782ed
+                        # we need the nodeId (the last part of the url) to create an API request for its metadata
+                        twillo_node_id: str | None = self.extract_twillo_node_id_from_url(twillo_url)
+                        if twillo_node_id:
+                            # if a twillo nodeId was found, the complete item will be yielded by its own method
+                            yield from self.request_metadata_for_twillo_node_id(
+                                base_itemloader=base,
+                                lom_base_itemloader=lom,
+                                lom_classification_itemloader=classification,
+                                lom_educational_itemloader=educational,
+                                lom_general_itemloader=general,
+                                lom_technical_itemloader=technical,
+                                license_itemloader=license_loader,
+                                valuespaces_itemloader=vs,
+                                elastic_item=elastic_item,
+                                twillo_node_id=twillo_node_id,
+                            )
+                            return None  # necessary to not accidentally parse the same twillo item twice!
                     if query_parameter_provider_name == "vhb":
                         self.enrich_vhb_metadata(base, elastic_item, general, in_languages)
         # --- BIRD HOOKS END HERE!

--- a/tests/test_duration_conversion.py
+++ b/tests/test_duration_conversion.py
@@ -6,6 +6,7 @@ from converter.pipelines import determine_duration_and_convert_to_seconds
 @pytest.mark.parametrize("test_input, expected_result",
                          [
                              ("", None),
+                             ("0", 0),
                              ("12:30:55", 45055),  # 43200s + 1800s + 55s = 45055s
                              ("08:25:24", 30324),  # 28800s + 1500s + 24s = 30324s
                              ("8:8:8", 29288),  # 28800s + 480s + 8s = 29288


### PR DESCRIPTION
This PR inlcudes the following changes:
- `oersi_spider` v0.2.7 (first PoC of BIRD "twillo" metadata enrichment)
  - feat: fetch metadata from twillo for BIRD `course_duration` & `course_learningoutcome`
  - feat: fetch metadata from twillo for `cclom:educational_description`
- several bugfixes and pipeline improvements
- feat: connect `LomEducationalItem.description` with the edu-sharing backend (`cclom:educational_description`)
- feat: crawler for BNE-Portal.de (for details, please check PR #106 )
  - (this PR also introduces two new (optional) control settings for the rendering of JavaScript heavy websites via playwright / headless browser!)