### PR TITLE
Fix "httpx"-related ReadErrors in `es_connector`

### DIFF
--- a/.run/merlin_spider.run.xml
+++ b/.run/merlin_spider.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="merlin_spider" type="PythonConfigurationType" factoryName="Python">
+    <output_file path="$PROJECT_DIR$/logs/merlin_spider_console.log" is_save="true" />
+    <module name="oeh-search-etl" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="./.venv/bin/scrapy" />
+    <option name="PARAMETERS" value="crawl oersi_spider -O &quot;../../logs/merlin_spider.json&quot;" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -939,13 +939,18 @@ class EduSharingCheckPipeline(EduSharing, BasicPipeline):
         db_item = self.find_item(item["sourceId"], spider)
         if db_item:
             if item["hash"] != db_item[1]:
-                log.debug(f"hash has changed, continuing pipelines for item {item['sourceId']}")
+                log.debug(f"EduSharingCheckPipeline: hash has changed. Continuing pipelines for item {item['sourceId']}")
             else:
-                log.debug(f"hash unchanged, skipping item {item['sourceId']}")
-                # self.update(item['sourceId'], spider)
-                # for tests, we update everything for now
-                # activate this later
-                # raise DropItem()
+                if "EDU_SHARING_FORCE_UPDATE" in spider.custom_settings and spider.custom_settings["EDU_SHARING_FORCE_UPDATE"]:
+                    log.debug(f"EduSharingCheckPipeline: hash unchanged for item {item['sourceId']}, "
+                              f"but detected active 'force item update'-setting (resetVersion / forceUpdate). "
+                              f"Continuing pipelines ...")
+                else:
+                    log.debug(f"EduSharingCheckPipeline: hash unchanged, skipping item {item['sourceId']}")
+                    # self.update(item['sourceId'], spider)
+                    # for tests, we update everything for now
+                    # activate this later
+                    # raise DropItem()
         return raw_item
 
 class EduSharingTypeValidationPipeline(BasicPipeline):

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -1103,7 +1103,7 @@ class EduSharingStorePipeline(EduSharing, BasicPipeline):
         if "title" in item["lom"]["general"]:
             title = str(item["lom"]["general"]["title"])
         entryUUID = EduSharing.build_uuid(item["response"]["url"] if "url" in item["response"] else item["hash"])
-        await self.insert_item(spider, entryUUID, item)
+        self.insert_item(spider, entryUUID, item)
         log.info("item " + entryUUID + " inserted/updated")
 
         # @TODO: We may need to handle Collections

--- a/converter/spiders/base_classes/lom_base.py
+++ b/converter/spiders/base_classes/lom_base.py
@@ -43,6 +43,9 @@ class LomBase:
             logging.info(
                 f"resetVersion requested, will force update + reset versions for crawler {self.name}"
             )
+            # populate the custom_settings so we can read the value more comfortably
+            # when an item passes through the pipeline
+            self.custom_settings.update({"EDU_SHARING_FORCE_UPDATE": True})
             # EduSharing().deleteAll(self)
             EduSharing.resetVersion = True
             self.forceUpdate = True


### PR DESCRIPTION
This PR includes the following changes:
- replaced async [httpx](https://www.python-httpx.org)-usage in `es_connector` with a [Session Object](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects) from the `requests`-package
  - this change was necessary because seemingly random `httpx.ReadError`s occured during crawls, which appear to be related to large payloads (especially when uploading thumbnail data or fulltext data to the edu-sharing repository)
- improve logging message during crawls when the [Spider Argument](https://docs.scrapy.org/en/latest/topics/spiders.html#spider-arguments) `resetVersion=true` is enabled 
  - _(this setting forces item updates in edu-sharing)_
  - previously the logging message did not reflect the active setting, which made debug logs slightly confusing
- `merlin_spider` bugfixes:
  - after the last refactoring of LomBase (which changed some methods `async`), `merlin_spider` was missing some `await` and `async` statements, which caused RunTimeErrors
  - fixed pydantic `ValidationError` due to `getHash()`-method returning an `int`-value instead of a `str`-value