### PR TITLE
Improved Exception Handling during website-screenshot fallback and several fixes for `pydantic` ValidationErrors

### DIFF
--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -412,16 +412,19 @@ class EduSharing:
 
         if "technical" in item["lom"]:
             if "duration" in item["lom"]["technical"]:
-                duration = item["lom"]["technical"]["duration"]
+                duration: str | int | None = item["lom"]["technical"]["duration"]
+                # after passing through the pipelines, the duration value should be in seconds
                 try:
-                    # edusharing requires milliseconds
+                    # edu-sharing requires values to be in milliseconds:
                     duration = int(float(duration) * 1000)
+                    # the edu-sharing API expects values to be wrapped in a string,
+                    # otherwise pydantic throws ValidationErrors during POST requests:
+                    duration = str(duration)
                 except ValueError:
                     log.debug(
                         f"The supplied 'technical.duration'-value {duration} could not be converted from "
                         f"seconds to milliseconds. ('cclom:duration' expects ms)"
                     )
-                    pass
                 spaces["cclom:duration"] = duration
             if "format" in item["lom"]["technical"]:
                 spaces["cclom:format"] = item["lom"]["technical"]["format"]

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -334,7 +334,12 @@ class EduSharing:
                     )
         if "internal" in license:
             match license["internal"]:
-                case "CC_0" | "CC_BY" | "CC_BY_NC" | "CC_BY_NC_ND" | "CC_BY_NC_SA" | "CC_BY_ND" | "CC_BY_SA" | "PDM" | Constants.LICENSE_COPYRIGHT_FREE | Constants.LICENSE_COPYRIGHT_LAW | Constants.LICENSE_SCHULFUNK | Constants.LICENSE_UNTERRICHTS_UND_SCHULMEDIEN:
+                case ("CC_0" | "CC_BY" | "CC_BY_NC" | "CC_BY_NC_ND" | "CC_BY_NC_SA" | "CC_BY_ND" | "CC_BY_SA" | "PDM" |
+                      Constants.LICENSE_COPYRIGHT_FREE |
+                      Constants.LICENSE_COPYRIGHT_LAW |
+                      Constants.LICENSE_SCHULFUNK |
+                      Constants.LICENSE_UNTERRICHTS_UND_SCHULMEDIEN |
+                      Constants.LICENSE_NONPUBLIC):
                     spaces["ccm:commonlicense_key"] = license["internal"]
                 case Constants.LICENSE_CUSTOM:
                     spaces["ccm:commonlicense_key"] = "CUSTOM"

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -960,6 +960,11 @@ class EduSharingTypeValidationPipeline(BasicPipeline):
     # ToDo: if you notice pydantic "ValidationError"s during crawls, implement handling of those edge-cases here!
     def process_item(self, item: scrapy.Item, spider: scrapy.Spider) -> Optional[scrapy.Item]:
         item_adapter = ItemAdapter(item)
+        if "hash" in item_adapter:
+            hash_value: int | str | None = item_adapter["hash"]
+            if hash_value and isinstance(hash_value, int):
+                # old crawlers might have returned hash values as integers, but the API expects a string
+                item_adapter["hash"] = str(hash_value)
         if "course" in item_adapter:
             course_item: dict = item_adapter["course"]
             if "course_duration" in course_item:

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -989,6 +989,10 @@ class EduSharingTypeValidationPipeline(BasicPipeline):
                             lom_educational["typicalAgeRange"]["toRange"] = str(to_range)
             if "general" in item_adapter["lom"]:
                 lom_general: dict = item_adapter["lom"]["general"]
+                if "aggregationLevel" in lom_general:
+                    aggregation_level: int | str | None = lom_general["aggregationLevel"]
+                    if aggregation_level and isinstance(aggregation_level, int):
+                        lom_general["aggregationLevel"] = str(aggregation_level)
                 if "keyword" in lom_general:
                     keywords: list[str] | set[str] | None = lom_general["keyword"]
                     if keywords and isinstance(keywords, set):

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+
 # Define your item pipelines here
 #
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
@@ -90,7 +91,7 @@ class PipelineWithPerSpiderMethods(metaclass=ABCMeta):
 
 class PipelineWithFactoryMethod(metaclass=ABCMeta):
     @classmethod
-    def from_crawler(cls, crawler: scrapy.crawler.Crawler) -> 'PipelineWithFactoryMethod':
+    def from_crawler(cls, crawler: scrapy.crawler.Crawler) -> "PipelineWithFactoryMethod":
         """
         If present, this classmethod is called to create a pipeline instance
         from a :class:`~scrapy.crawler.Crawler`. It must return a new instance
@@ -121,18 +122,16 @@ class FilterSparsePipeline(BasicPipeline):
         item = ItemAdapter(raw_item)
         try:
             if "title" not in item["lom"]["general"]:
-                raise DropItem(
-                    "Entry {} has no title location".format(item["sourceId"])
-                )
+                raise DropItem("Entry {} has no title location".format(item["sourceId"]))
         except KeyError:
-            raise DropItem(f'Item {item} has no lom.technical.location')
+            raise DropItem(f"Item {item} has no lom.technical.location")
         try:
             if "location" not in item["lom"]["technical"] and "binary" not in item:
                 raise DropItem(
                     "Entry {} has no technical location or binary data".format(item["lom"]["general"]["title"])
                 )
         except KeyError:
-            raise DropItem(f'Item {item} has no lom.technical.location')
+            raise DropItem(f"Item {item} has no lom.technical.location")
         # pass through explicit uuid elements
         if "uuid" in item:
             return raw_item
@@ -157,13 +156,9 @@ class FilterSparsePipeline(BasicPipeline):
         # if none of the above matches drop the item
 
         try:
-            raise DropItem(
-                "Entry "
-                + item["lom"]["general"]["title"]
-                + " has neither keywords nor description"
-            )
+            raise DropItem("Entry " + item["lom"]["general"]["title"] + " has neither keywords nor description")
         except KeyError:
-            raise DropItem(f'Item {item} was dropped for not providing enough metadata')
+            raise DropItem(f"Item {item} was dropped for not providing enough metadata")
 
 
 class NormLanguagePipeline(BasicPipeline):
@@ -203,8 +198,7 @@ class NormLicensePipeline(BasicPipeline):
                     item["license"]["url"] = Constants.LICENSE_MAPPINGS[key]
                     break
         if "internal" in item["license"] and (
-                "url" not in item["license"]
-                or item["license"]["url"] not in Constants.VALID_LICENSE_URLS
+            "url" not in item["license"] or item["license"]["url"] not in Constants.VALID_LICENSE_URLS
         ):
             for key in Constants.LICENSE_MAPPINGS_INTERNAL:
                 if item["license"]["internal"].casefold() == key.casefold():
@@ -214,17 +208,19 @@ class NormLicensePipeline(BasicPipeline):
 
         if "url" in item["license"] and "oer" not in item["license"]:
             match item["license"]["url"]:
-                case Constants.LICENSE_CC_BY_10 | \
-                     Constants.LICENSE_CC_BY_20 | \
-                     Constants.LICENSE_CC_BY_25 | \
-                     Constants.LICENSE_CC_BY_30 | \
-                     Constants.LICENSE_CC_BY_40 | \
-                     Constants.LICENSE_CC_BY_SA_10 | \
-                     Constants.LICENSE_CC_BY_SA_20 | \
-                     Constants.LICENSE_CC_BY_SA_25 | \
-                     Constants.LICENSE_CC_BY_SA_30 | \
-                     Constants.LICENSE_CC_BY_SA_40 | \
-                     Constants.LICENSE_CC_ZERO_10:
+                case (
+                    Constants.LICENSE_CC_BY_10
+                    | Constants.LICENSE_CC_BY_20
+                    | Constants.LICENSE_CC_BY_25
+                    | Constants.LICENSE_CC_BY_30
+                    | Constants.LICENSE_CC_BY_40
+                    | Constants.LICENSE_CC_BY_SA_10
+                    | Constants.LICENSE_CC_BY_SA_20
+                    | Constants.LICENSE_CC_BY_SA_25
+                    | Constants.LICENSE_CC_BY_SA_30
+                    | Constants.LICENSE_CC_BY_SA_40
+                    | Constants.LICENSE_CC_ZERO_10
+                ):
                     item["license"]["oer"] = OerType.ALL
                 case _:
                     # ToDo: log default case if not too spammy
@@ -247,8 +243,10 @@ class NormLicensePipeline(BasicPipeline):
                         # happy-case: the 'date' property is of type datetime
                         pass
                     elif lifecycle_date:
-                        log.warning(f"Lifecycle Pipeline received invalid 'date'-value: {lifecycle_date} !"
-                                    f"Expected type 'str' or 'datetime', but received: {type(lifecycle_date)} instead.")
+                        log.warning(
+                            f"Lifecycle Pipeline received invalid 'date'-value: {lifecycle_date} !"
+                            f"Expected type 'str' or 'datetime', but received: {type(lifecycle_date)} instead."
+                        )
 
         return raw_item
 
@@ -270,17 +268,13 @@ class ConvertTimePipeline(BasicPipeline):
                     date = dateutil.parser.parse(item["lastModified"])
                     item["lastModified"] = int(date.timestamp())
                 except ValueError:
-                    log.warning(
-                        "Unable to parse given lastModified date "
-                        + item["lastModified"]
-                    )
+                    log.warning("Unable to parse given lastModified date " + item["lastModified"])
                     del item["lastModified"]
 
         if "typicalLearningTime" in item["lom"]["educational"]:
             tll_raw = item["lom"]["educational"]["typicalLearningTime"]
-            tll_duration_in_seconds = (
-                determine_duration_and_convert_to_seconds(time_raw=tll_raw,
-                                                          item_field_name="LomEducationalItem.typicalLearningTime")
+            tll_duration_in_seconds = determine_duration_and_convert_to_seconds(
+                time_raw=tll_raw, item_field_name="LomEducationalItem.typicalLearningTime"
             )
             # ToDo: update es_connector and connect this property with the backend
             item["lom"]["educational"]["typicalLearningTime"] = tll_duration_in_seconds
@@ -289,14 +283,13 @@ class ConvertTimePipeline(BasicPipeline):
             if "duration" in item["lom"]["technical"]:
                 raw_duration = item["lom"]["technical"]["duration"]
                 duration_in_seconds = determine_duration_and_convert_to_seconds(
-                    time_raw=raw_duration,
-                    item_field_name="LomTechnicalItem.duration")
+                    time_raw=raw_duration, item_field_name="LomTechnicalItem.duration"
+                )
                 item["lom"]["technical"]["duration"] = duration_in_seconds
         return raw_item
 
 
-def determine_duration_and_convert_to_seconds(time_raw: str | int | float,
-                                              item_field_name: str) -> int | None:
+def determine_duration_and_convert_to_seconds(time_raw: str | int | float, item_field_name: str) -> int | None:
     """
     Tries to convert "duration"-objects (of unknown type) to seconds.
     Returns the converted duration as(as total seconds) int value if successful
@@ -316,14 +309,12 @@ def determine_duration_and_convert_to_seconds(time_raw: str | int | float,
             # handling of "hh:mm:ss"-durations:
             t_split: list[str] = time_raw.split(":")
             if len(t_split) == 3:
-                time_in_seconds = (
-                        int(t_split[0]) * 60 * 60
-                        + int(t_split[1]) * 60
-                        + int(t_split[2])
-                )
+                time_in_seconds = int(t_split[0]) * 60 * 60 + int(t_split[1]) * 60 + int(t_split[2])
             else:
-                log.warning(f"Encountered unhandled edge-case in '{item_field_name}': "
-                            f"Expected format 'hh:mm:ss', but received {time_raw} instead.")
+                log.warning(
+                    f"Encountered unhandled edge-case in '{item_field_name}': "
+                    f"Expected format 'hh:mm:ss', but received {time_raw} instead."
+                )
         if time_raw.startswith("P"):
             # handling of iso-formatted duration strings, e.g. "P14DT22H" or "P7W"
             # (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)
@@ -336,16 +327,20 @@ def determine_duration_and_convert_to_seconds(time_raw: str | int | float,
                     # timedelta object can't handle conversion from months to .total_seconds()
                     # see: https://github.com/gweis/isodate/issues/44
                     # and https://docs.python.org/3/library/datetime.html#datetime.timedelta
-                    log.warning(f"Unhandled value detected: Cannot transform {time_raw} to total seconds!"
-                                f"(months (M) or years (Y) aren't standardized duration units)")
+                    log.warning(
+                        f"Unhandled value detected: Cannot transform {time_raw} to total seconds!"
+                        f"(months (M) or years (Y) aren't standardized duration units)"
+                    )
                     time_in_seconds = None
                     # ToDo: choose an acceptable solution
                     #  1) either approximate the total seconds (inaccurate: "P6M" becomes 6 x 4W = 24W)
                     #    -> this would require RegEx parsing and string replacement of the month/year parts
                     #  2) or keep the string representation AND find a better suited edu-sharing property for durations
             else:
-                log.warning(f"Encountered unhandled edge-case in '{item_field_name}': "
-                            f"Expected ISO-8601 duration string, but received {time_raw} instead.")
+                log.warning(
+                    f"Encountered unhandled edge-case in '{item_field_name}': "
+                    f"Expected ISO-8601 duration string, but received {time_raw} instead."
+                )
         if "." in time_raw and time_raw.count(".") == 1:
             # duration strings might come with float precision (e.g. "600.0" for 10 Minutes)
             try:
@@ -353,30 +348,37 @@ def determine_duration_and_convert_to_seconds(time_raw: str | int | float,
                 if seconds_float:
                     time_in_seconds = int(seconds_float)
             except ValueError:
-                log.warning(
-                    f"Unable to convert string {time_raw} (type: {type(time_raw)}) to 'int'-value (seconds).")
+                log.warning(f"Unable to convert string {time_raw} (type: {type(time_raw)}) to 'int'-value (seconds).")
         if time_raw.isnumeric():
             try:
                 time_in_seconds = int(time_raw)
             except ValueError:
-                log.warning(f"Unable to convert 'duration'-value {time_raw} (type ({type(time_raw)}) "
-                            f"to 'int'-value (seconds).")
+                log.warning(
+                    f"Unable to convert 'duration'-value {time_raw} (type ({type(time_raw)}) "
+                    f"to 'int'-value (seconds)."
+                )
         # ToDo (optional): implement processing of natural language strings? (e.g. "12 Stunden")
         #  - this feature would need a rigorous testing suite for common expressions (English and German strings)
     else:
         try:
             time_in_seconds = int(time_raw)
         except ValueError:
-            log.warning(f"'duration' value {time_raw} could not be normalized to seconds. "
-                        f"(Unhandled edge-case: Expected int or float value, "
-                        f"but received {type(time_raw)} instead.")
+            log.warning(
+                f"'duration' value {time_raw} could not be normalized to seconds. "
+                f"(Unhandled edge-case: Expected int or float value, "
+                f"but received {type(time_raw)} instead."
+            )
     if not time_in_seconds:
         if isinstance(time_in_seconds, int) and time_in_seconds == 0:
-            log.debug(f"Detected zero duration for '{item_field_name}'.  "
-                      f"Received raw value: {time_raw} of type {type(time_raw)} .")
+            log.debug(
+                f"Detected zero duration for '{item_field_name}'.  "
+                f"Received raw value: {time_raw} of type {type(time_raw)} ."
+            )
         else:
-            log.warning(f"Unable to convert '{item_field_name}'-value (type: {type(time_raw)}) from {time_raw} "
-                        f"to numeric value (seconds).")
+            log.warning(
+                f"Unable to convert '{item_field_name}'-value (type: {type(time_raw)}) from {time_raw} "
+                f"to numeric value (seconds)."
+            )
     return time_in_seconds
 
 
@@ -400,14 +402,18 @@ class CourseItemPipeline(BasicPipeline):
                         caf_iso: str = caf_parsed.isoformat()
                         course_adapter["course_availability_from"] = caf_iso
                     else:
-                        log.warning(f"Failed to parse \"course_availability_from\"-property "
-                                    f"\"{course_availability_from}\" to a valid \"datetime\"-object. \n"
-                                    f"(Please check the object {item_adapter['sourceId']} "
-                                    f"or extend the CourseItemPipeline!)")
+                        log.warning(
+                            f'Failed to parse "course_availability_from"-property '
+                            f'"{course_availability_from}" to a valid "datetime"-object. \n'
+                            f"(Please check the object {item_adapter['sourceId']} "
+                            f"or extend the CourseItemPipeline!)"
+                        )
                         del course_adapter["course_availability_from"]
                 else:
-                    log.warning(f"Cannot process BIRD 'course_availability_from'-property {course_availability_from} "
-                                f"(Expected a string, but received {type(course_availability_from)} instead.")
+                    log.warning(
+                        f"Cannot process BIRD 'course_availability_from'-property {course_availability_from} "
+                        f"(Expected a string, but received {type(course_availability_from)} instead."
+                    )
                     del course_adapter["course_availability_from"]
 
             # Prepare BIRD "course_availability_until" for "ccm:oeh_event_end" (-> ISO-formatted "datetime"-string)
@@ -420,15 +426,18 @@ class CourseItemPipeline(BasicPipeline):
                         cau_iso: str = cau_parsed.isoformat()
                         course_adapter["course_availability_until"] = cau_iso
                     else:
-                        log.warning(f"Failed to parse \"{course_availability_until}\" to a valid 'datetime'-object. "
-                                    f"(Please check the object {item_adapter['sourceId']} for unhandled edge-cases or "
-                                    f"extend the CourseItemPipeline!)")
+                        log.warning(
+                            f"Failed to parse \"{course_availability_until}\" to a valid 'datetime'-object. "
+                            f"(Please check the object {item_adapter['sourceId']} for unhandled edge-cases or "
+                            f"extend the CourseItemPipeline!)"
+                        )
                         del course_adapter["course_availability_until"]
                 else:
                     log.warning(
-                        f"Cannot process BIRD \"course_availability_until\"-property {course_availability_until} "
+                        f'Cannot process BIRD "course_availability_until"-property {course_availability_until} '
                         f"(Expected a string, but received {type(course_availability_until)} instead.) "
-                        f"Deleting property...")
+                        f"Deleting property..."
+                    )
                     del course_adapter["course_availability_until"]
 
             if "course_description_short" in course_adapter:
@@ -438,17 +447,18 @@ class CourseItemPipeline(BasicPipeline):
                     # happy-case: the description is a string
                     pass
                 else:
-                    log.warning(f"Cannot process BIRD 'course_description_short'-property for item "
-                                f"{item_adapter['sourceId']} . Expected a string, but received "
-                                f"{type(course_description_short)} instead. Deleting property...")
+                    log.warning(
+                        f"Cannot process BIRD 'course_description_short'-property for item "
+                        f"{item_adapter['sourceId']} . Expected a string, but received "
+                        f"{type(course_description_short)} instead. Deleting property..."
+                    )
                     del course_adapter["course_description_short"]
 
             if "course_duration" in course_adapter:
                 # course_duration -> 'cclom:typicallearningtime' (ms)
                 course_duration: int = course_adapter["course_duration"]
                 course_duration = determine_duration_and_convert_to_seconds(
-                    time_raw=course_duration,
-                    item_field_name="CourseItem.course_duration"
+                    time_raw=course_duration, item_field_name="CourseItem.course_duration"
                 )
                 if isinstance(course_duration, int):
                     if course_duration:
@@ -457,13 +467,17 @@ class CourseItemPipeline(BasicPipeline):
                     elif course_duration == 0:
                         # a duration of zero seconds is not a valid time duration, but most likely just a limitation
                         # of different backend systems how they store "empty" values for this metadata property.
-                        log.debug(f"Received zero duration value within 'course_duration'-property of item "
-                                  f"{item_adapter['sourceId']}. Deleting property ...")
+                        log.debug(
+                            f"Received zero duration value within 'course_duration'-property of item "
+                            f"{item_adapter['sourceId']}. Deleting property ..."
+                        )
                         del course_adapter["course_duration"]
                 else:
-                    log.warning(f"Cannot process BIRD 'course_duration'-property for item {item_adapter['sourceId']} . "
-                                f"Expected a single (positive) integer value (in seconds), "
-                                f"but received {type(course_duration)} instead. Deleting property...")
+                    log.warning(
+                        f"Cannot process BIRD 'course_duration'-property for item {item_adapter['sourceId']} . "
+                        f"Expected a single (positive) integer value (in seconds), "
+                        f"but received {type(course_duration)} instead. Deleting property..."
+                    )
                     del course_adapter["course_duration"]
 
             if "course_learningoutcome" in course_adapter:
@@ -481,15 +495,18 @@ class CourseItemPipeline(BasicPipeline):
                                 course_learning_outcome_clean.append(clo_candidate)
                             else:
                                 # if the list item isn't a string, we won't save it to the cleaned up list
-                                log.warning(f"Received unexpected type as part of 'course_learningoutcome': "
-                                            f"Expected list[str], but received a {type(clo_candidate)} "
-                                            f"instead. Raw value: {clo_candidate}")
+                                log.warning(
+                                    f"Received unexpected type as part of 'course_learningoutcome': "
+                                    f"Expected list[str], but received a {type(clo_candidate)} "
+                                    f"instead. Raw value: {clo_candidate}"
+                                )
                         course_adapter["course_learningoutcome"] = course_learning_outcome_clean
                 else:
                     log.warning(
                         f"Cannot process BIRD 'course_learningoutcome'-property for item {item_adapter['sourceId']} "
                         f". Expected a string, but received {type(course_learning_outcome)} instead. "
-                        f"Deleting property...")
+                        f"Deleting property..."
+                    )
                     del course_adapter["course_learningoutcome"]
 
             if "course_schedule" in course_adapter:
@@ -499,9 +516,11 @@ class CourseItemPipeline(BasicPipeline):
                     # happy-case
                     pass
                 else:
-                    log.warning(f"Cannot process BIRD 'course_schedule'-property for item {item_adapter['sourceId']} . "
-                                f"Expected a string, but received {type(course_schedule)} instead. "
-                                f"Deleting property...")
+                    log.warning(
+                        f"Cannot process BIRD 'course_schedule'-property for item {item_adapter['sourceId']} . "
+                        f"Expected a string, but received {type(course_schedule)} instead. "
+                        f"Deleting property..."
+                    )
                     del course_adapter["course_schedule"]
 
             if "course_url_video" in course_adapter:
@@ -514,7 +533,8 @@ class CourseItemPipeline(BasicPipeline):
                     log.warning(
                         f"Cannot process BIRD 'course_url_video'-property for item {item_adapter['sourceId']} . "
                         f"Expected a string, but received {type(course_url_video)} instead. "
-                        f"Deleting property...")
+                        f"Deleting property..."
+                    )
                     del course_adapter["course_url_video"]
 
             if "course_workload" in course_adapter:
@@ -526,8 +546,10 @@ class CourseItemPipeline(BasicPipeline):
                     #  (and which type is expected) -> implement a type-check!
                     course_workload: str = course_adapter["course_workload"]
                     if course_workload:
-                        log.error(f"Cannot process BIRD 'course_workload'-property: this field is not implemented yet! "
-                                  f"(Please update the 'CourseItemPipeline' (pipelines.py) and es_connector.py!)")
+                        log.error(
+                            f"Cannot process BIRD 'course_workload'-property: this field is not implemented yet! "
+                            f"(Please update the 'CourseItemPipeline' (pipelines.py) and es_connector.py!)"
+                        )
                         pass
                 pass
 
@@ -589,6 +611,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
     """
     generate thumbnails
     """
+
     pixel_limit: int = 178956970  # ~179 Megapixel
     pixel_limit_in_mp: float = pixel_limit / 1000000
     Image.MAX_IMAGE_PIXELS = pixel_limit  # doubles the Pillow default (89,478,485) → from 89,5 MegaPixels to 179 MP
@@ -644,22 +667,28 @@ class ProcessThumbnailPipeline(BasicPipeline):
                 # we expect that some thumbnail URLs will be wrong, outdated or already offline, which is why we catch
                 # the most common Exceptions while trying to dwonload the image.
             except twisted.internet.error.TCPTimedOutError:
-                log.warning(f"Thumbnail download of URL {url} failed due to TCPTimedOutError. "
-                            f"(You might see this error if the image is unavailable under that specific URL.) "
-                            f"Falling back to website screenshot.")
+                log.warning(
+                    f"Thumbnail download of URL {url} failed due to TCPTimedOutError. "
+                    f"(You might see this error if the image is unavailable under that specific URL.) "
+                    f"Falling back to website screenshot."
+                )
                 del item["thumbnail"]
                 return await self.process_item(raw_item, spider)
             except twisted.internet.error.DNSLookupError:
-                log.warning(f"Thumbnail download of URL {url} failed due to DNSLookupError. "
-                            f"(The webserver might be offline.) Falling back to website screenshot.")
+                log.warning(
+                    f"Thumbnail download of URL {url} failed due to DNSLookupError. "
+                    f"(The webserver might be offline.) Falling back to website screenshot."
+                )
                 del item["thumbnail"]
                 return await self.process_item(raw_item, spider)
             time_end: datetime = datetime.datetime.now()
             log.debug(f"Loading thumbnail from {url} took {time_end - time_start} (incl. awaiting).")
             log.debug(f"Thumbnail-URL-Cache: {self.download_thumbnail_url.cache_info()} after trying to query {url} ")
             if thumbnail_response.status != 200:
-                log.debug(f"Thumbnail-Pipeline received an unexpected response (status: {thumbnail_response.status}) "
-                          f"from {url} (-> resolved URL: {thumbnail_response.url}")
+                log.debug(
+                    f"Thumbnail-Pipeline received an unexpected response (status: {thumbnail_response.status}) "
+                    f"from {url} (-> resolved URL: {thumbnail_response.url}"
+                )
                 # falling back to website screenshot:
                 del item["thumbnail"]
                 return await self.process_item(raw_item, spider)
@@ -678,28 +707,31 @@ class ProcessThumbnailPipeline(BasicPipeline):
                         # only set the response if thumbnail retrieval was successful!
                     elif _mimetype == "application/octet-stream":
                         # ToDo: special handling for 'application/octet-stream' necessary?
-                        log.debug(f"Thumbnail URL of MIME-Type 'image/...' expected, "
-                                  f"but received '{_mimetype}' instead. "
-                                  f"(If thumbnail conversion throws unexpected errors further down the line, "
-                                  f"the Thumbnail-Pipeline needs to be re-visited! URL: {url} )")
+                        log.debug(
+                            f"Thumbnail URL of MIME-Type 'image/...' expected, "
+                            f"but received '{_mimetype}' instead. "
+                            f"(If thumbnail conversion throws unexpected errors further down the line, "
+                            f"the Thumbnail-Pipeline needs to be re-visited! URL: {url} )"
+                        )
                         response = thumbnail_response
                     else:
-                        log.warning(f"Thumbnail URL {url} does not seem to be an image! "
-                                    f"Header contained Content-Type '{_mimetype}' instead. "
-                                    f"(Falling back to screenshot)")
+                        log.warning(
+                            f"Thumbnail URL {url} does not seem to be an image! "
+                            f"Header contained Content-Type '{_mimetype}' instead. "
+                            f"(Falling back to screenshot)"
+                        )
                         del item["thumbnail"]
                         return await self.process_item(raw_item, spider)
                 except KeyError:
-                    log.warning(f"Thumbnail URL response did not contain a Content-Type / MIME-Type! "
-                                f"Thumbnail URL queried: {url} "
-                                f"-> resolved URL: {thumbnail_response.url} "
-                                f"(HTTP Status: {thumbnail_response.status}")
+                    log.warning(
+                        f"Thumbnail URL response did not contain a Content-Type / MIME-Type! "
+                        f"Thumbnail URL queried: {url} "
+                        f"-> resolved URL: {thumbnail_response.url} "
+                        f"(HTTP Status: {thumbnail_response.status}"
+                    )
                     del item["thumbnail"]
                     return await self.process_item(raw_item, spider)
-        elif (
-                "location" in item["lom"]["technical"]
-                and len(item["lom"]["technical"]["location"]) > 0
-        ):
+        elif "location" in item["lom"]["technical"] and len(item["lom"]["technical"]["location"]) > 0:
             if settings_crawler.get("SPLASH_URL") and web_tools == WebEngine.Splash:
                 target_url: str = item["lom"]["technical"]["location"][0]
                 _splash_url: str = f"{settings_crawler.get('SPLASH_URL')}/render.png"
@@ -710,33 +742,38 @@ class ProcessThumbnailPipeline(BasicPipeline):
                     "url": target_url,
                     "wait": _splash_parameter_wait,
                     "html5_media": _splash_parameter_wait,
-                    "headers": _splash_headers
+                    "headers": _splash_headers,
                 }
                 request_splash = scrapy.FormRequest(
-                    url=_splash_url,
-                    formdata=_splash_dict,
-                    callback=NO_CALLBACK,
-                    priority=1
+                    url=_splash_url, formdata=_splash_dict, callback=NO_CALLBACK, priority=1
                 )
                 splash_response: scrapy.http.Response = await maybe_deferred_to_future(
                     spider.crawler.engine.download(request_splash)
                 )
                 if splash_response and splash_response.status != 200:
-                    log.debug(f"SPLASH could not handle the requested website. "
-                              f"(Splash returned HTTP Status {splash_response.status} for {target_url} !)")
+                    log.debug(
+                        f"SPLASH could not handle the requested website. "
+                        f"(Splash returned HTTP Status {splash_response.status} for {target_url} !)"
+                    )
                     _splash_success = False
                     # ToDo (optional): more granular Error-Handling for unsupported URLs?
                     if splash_response.status == 415:
-                        log.debug(f"SPLASH (HTTP Status {splash_response.status} -> Unsupported Media Type): "
-                                  f"Could not render target url {target_url}")
+                        log.debug(
+                            f"SPLASH (HTTP Status {splash_response.status} -> Unsupported Media Type): "
+                            f"Could not render target url {target_url}"
+                        )
                 elif splash_response:
                     response: scrapy.http.Response = splash_response
                 else:
                     log.debug(f"SPLASH returned HTTP Status {splash_response.status} for {target_url} ")
 
             playwright_websocket_endpoint: str | None = env.get("PLAYWRIGHT_WS_ENDPOINT")
-            if (not bool(_splash_success) and playwright_websocket_endpoint
-                    or playwright_websocket_endpoint and web_tools == WebEngine.Playwright):
+            if (
+                not bool(_splash_success)
+                and playwright_websocket_endpoint
+                or playwright_websocket_endpoint
+                and web_tools == WebEngine.Playwright
+            ):
                 # we're using Playwright to take a website screenshot if:
                 # - the spider explicitly defined Playwright in its 'custom_settings'-dict
                 # - or: Splash failed to render a website (= fallback)
@@ -748,32 +785,40 @@ class ProcessThumbnailPipeline(BasicPipeline):
                 target_url: str = item["lom"]["technical"]["location"][0]
 
                 playwright_dict = await self.take_website_screenshot_with_playwright(
-                    spider=spider,
-                    target_url=target_url)
+                    spider=spider, target_url=target_url
+                )
                 try:
                     screenshot_bytes: bytes | None = playwright_dict.get("screenshot_bytes")
                 except AttributeError:
                     screenshot_bytes = None
-                    log.debug(f"Failed fallback #1: taking a website-screenshot of URL "
-                              f"{target_url} wasn't possible!")
-                    if lom_technical_location and isinstance(lom_technical_location, list) and len(
-                            lom_technical_location) >= 2:
+                    log.debug(
+                        f"Failed fallback #1: taking a website-screenshot of URL " f"{target_url} wasn't possible!"
+                    )
+                    if (
+                        lom_technical_location
+                        and isinstance(lom_technical_location, list)
+                        and len(lom_technical_location) >= 2
+                    ):
                         # this edge-case might happen during crawls of items with multiple URLs:
                         # the first URL might be a direct-link to an audio/video file (example: podcast episode as .mp3)
                         # while the second URL might point towards the webpage of said podcast episode
                         target_url_2nd: str = lom_technical_location[1]
                         if target_url_2nd and isinstance(target_url_2nd, str):
-                            log.debug(f"Second URL in LOM Technical Location detected. "
-                                      f"Trying to take a website-screenshot of {lom_technical_location[1]} (fallback #2)...")
+                            log.debug(
+                                f"Second URL in LOM Technical Location detected. "
+                                f"Trying to take a website-screenshot of {lom_technical_location[1]} (fallback #2)..."
+                            )
                             playwright_dict = await self.take_website_screenshot_with_playwright(
-                                spider=spider,
-                                target_url=target_url_2nd)
+                                spider=spider, target_url=target_url_2nd
+                            )
                             try:
                                 screenshot_bytes: bytes | None = playwright_dict.get("screenshot_bytes")
                             except AttributeError:
                                 screenshot_bytes = None
-                                log.warning(f"Failed fallback #2: taking a website-screenshot of URL "
-                                            f"{target_url_2nd} wasn't possible!")
+                                log.warning(
+                                    f"Failed fallback #2: taking a website-screenshot of URL "
+                                    f"{target_url_2nd} wasn't possible!"
+                                )
                 if screenshot_bytes:
                     img = Image.open(BytesIO(screenshot_bytes))
                     self.create_thumbnails_from_image_bytes(img, item, settings_crawler)
@@ -805,9 +850,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
                         item["thumbnail"]["mimetype"] = _mimetype.decode()
                     elif _mimetype and isinstance(_mimetype, str):
                         item["thumbnail"]["mimetype"] = _mimetype
-                    item["thumbnail"]["small"] = base64.b64encode(
-                        response.body
-                    ).decode()
+                    item["thumbnail"]["small"] = base64.b64encode(response.body).decode()
                 else:
                     try:
                         img = Image.open(BytesIO(response.body))
@@ -817,7 +860,8 @@ class ProcessThumbnailPipeline(BasicPipeline):
                         if url:
                             log.warning(
                                 f"Thumbnail download of image file {url} failed: image file could not be identified "
-                                f"(Image might be broken or corrupt). Falling back to website-screenshot.")
+                                f"(Image might be broken or corrupt). Falling back to website-screenshot."
+                            )
                         del item["thumbnail"]
                         return await self.process_item(raw_item, spider)
                     except Image.DecompressionBombError:
@@ -826,10 +870,12 @@ class ProcessThumbnailPipeline(BasicPipeline):
                         # If such an error is thrown, the image object won't be available.
                         # Therefore, we need to fall back to a website screenshot.
                         absolute_pixel_limit_in_mp = (self.pixel_limit * 2) / 1000000
-                        log.warning(f"Thumbnail download of {url} triggered a 'PIL.Image.DecompressionBombError'! "
-                                    f"The image either exceeds the max size of {absolute_pixel_limit_in_mp} "
-                                    f"megapixels or might have been a DoS attempt. "
-                                    f"Falling back to website screenshot...")
+                        log.warning(
+                            f"Thumbnail download of {url} triggered a 'PIL.Image.DecompressionBombError'! "
+                            f"The image either exceeds the max size of {absolute_pixel_limit_in_mp} "
+                            f"megapixels or might have been a DoS attempt. "
+                            f"Falling back to website screenshot..."
+                        )
                         del item["thumbnail"]
                         return await self.process_item(raw_item, spider)
             except Exception as e:
@@ -841,9 +887,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
                     return await self.process_item(raw_item, spider)
                 else:
                     # item['thumbnail']={}
-                    raise DropItem(
-                        "No thumbnail provided or resource was unavailable for fetching"
-                    )
+                    raise DropItem("No thumbnail provided or resource was unavailable for fetching")
         return raw_item
 
     async def take_website_screenshot_with_playwright(self, spider: scrapy.Spider, target_url: str):
@@ -856,10 +900,9 @@ class ProcessThumbnailPipeline(BasicPipeline):
                 playwright_cookies = spider.custom_settings.get("PLAYWRIGHT_COOKIES")
             if "PLAYWRIGHT_ADBLOCKER" in spider.custom_settings:
                 playwright_adblock_enabled: bool = spider.custom_settings["PLAYWRIGHT_ADBLOCKER"]
-        playwright_dict = await WebTools.getUrlData(url=target_url,
-                                                    engine=WebEngine.Playwright,
-                                                    cookies=playwright_cookies,
-                                                    adblock=playwright_adblock_enabled)
+        playwright_dict = await WebTools.getUrlData(
+            url=target_url, engine=WebEngine.Playwright, cookies=playwright_cookies, adblock=playwright_adblock_enabled
+        )
         return playwright_dict
 
     @alru_cache(maxsize=128)
@@ -883,9 +926,7 @@ class ProcessThumbnailPipeline(BasicPipeline):
             request = scrapy.Request(url=url, callback=NO_CALLBACK, priority=1)
             # Thumbnail downloads will be executed with a slightly higher priority (default: 0), so there's less delay
             # between metadata processing and thumbnail retrieval steps in the pipelines
-            response: Deferred | Future = await maybe_deferred_to_future(
-                spider.crawler.engine.download(request)
-            )
+            response: Deferred | Future = await maybe_deferred_to_future(spider.crawler.engine.download(request))
             return response
         except ValueError:
             log.debug(f"Thumbnail-Pipeline received an invalid URL: {url}")
@@ -927,23 +968,20 @@ class ProcessThumbnailPipeline(BasicPipeline):
             )
             item["thumbnail"] = {}
             item["thumbnail"]["mimetype"] = "image/jpeg"
-            item["thumbnail"]["small"] = base64.b64encode(
-                small_buffer.getvalue()
-            ).decode()
-            item["thumbnail"]["large"] = base64.b64encode(
-                large_buffer.getvalue()
-            ).decode()
+            item["thumbnail"]["small"] = base64.b64encode(small_buffer.getvalue()).decode()
+            item["thumbnail"]["large"] = base64.b64encode(large_buffer.getvalue()).decode()
 
 
 def get_settings_for_crawler(spider) -> scrapy.settings.Settings:
     all_settings = get_project_settings()
-    crawler_settings = settings.BaseSettings(getattr(spider, "custom_settings") or {}, 'spider')
+    crawler_settings = settings.BaseSettings(getattr(spider, "custom_settings") or {}, "spider")
     if isinstance(crawler_settings, dict):
-        crawler_settings = settings.BaseSettings(crawler_settings, 'spider')
+        crawler_settings = settings.BaseSettings(crawler_settings, "spider")
     for key in crawler_settings.keys():
         if (
-                all_settings.get(key) and crawler_settings.getpriority(key) > all_settings.getpriority(key)
-                or not all_settings.get(key)
+            all_settings.get(key)
+            and crawler_settings.getpriority(key) > all_settings.getpriority(key)
+            or not all_settings.get(key)
         ):
             all_settings.set(key, crawler_settings.get(key), crawler_settings.getpriority(key))
     return all_settings
@@ -969,12 +1007,19 @@ class EduSharingCheckPipeline(EduSharing, BasicPipeline):
         db_item = self.find_item(item["sourceId"], spider)
         if db_item:
             if item["hash"] != db_item[1]:
-                log.debug(f"EduSharingCheckPipeline: hash has changed. Continuing pipelines for item {item['sourceId']}")
+                log.debug(
+                    f"EduSharingCheckPipeline: hash has changed. Continuing pipelines for item {item['sourceId']}"
+                )
             else:
-                if "EDU_SHARING_FORCE_UPDATE" in spider.custom_settings and spider.custom_settings["EDU_SHARING_FORCE_UPDATE"]:
-                    log.debug(f"EduSharingCheckPipeline: hash unchanged for item {item['sourceId']}, "
-                              f"but detected active 'force item update'-setting (resetVersion / forceUpdate). "
-                              f"Continuing pipelines ...")
+                if (
+                    "EDU_SHARING_FORCE_UPDATE" in spider.custom_settings
+                    and spider.custom_settings["EDU_SHARING_FORCE_UPDATE"]
+                ):
+                    log.debug(
+                        f"EduSharingCheckPipeline: hash unchanged for item {item['sourceId']}, "
+                        f"but detected active 'force item update'-setting (resetVersion / forceUpdate). "
+                        f"Continuing pipelines ..."
+                    )
                 else:
                     log.debug(f"EduSharingCheckPipeline: hash unchanged, skipping item {item['sourceId']}")
                     # self.update(item['sourceId'], spider)
@@ -983,10 +1028,12 @@ class EduSharingCheckPipeline(EduSharing, BasicPipeline):
                     # raise DropItem()
         return raw_item
 
+
 class EduSharingTypeValidationPipeline(BasicPipeline):
     """
     Rudimentary type-conversion before handling metadata properties off to the API client.
     """
+
     # ToDo: if you notice pydantic "ValidationError"s during crawls, implement handling of those edge-cases here!
     def process_item(self, item: scrapy.Item, spider: scrapy.Spider) -> Optional[scrapy.Item]:
         item_adapter = ItemAdapter(item)
@@ -1045,7 +1092,7 @@ class JSONStorePipeline(BasicPipeline, PipelineWithPerSpiderMethods):
         self.exporters: dict[str, JsonItemExporter] = {}
 
     def open_spider(self, spider):
-        file = open(f'output_{spider.name}.json', 'wb')
+        file = open(f"output_{spider.name}.json", "wb")
         self.files[spider.name] = file
         exporter = JsonItemExporter(
             file,
@@ -1062,9 +1109,10 @@ class JSONStorePipeline(BasicPipeline, PipelineWithPerSpiderMethods):
                 # "ranking",
                 # "thumbnail",
             ],
-            encoding='utf-8',
+            encoding="utf-8",
             indent=2,
-            ensure_ascii=False)
+            ensure_ascii=False,
+        )
         self.exporters[spider.name] = exporter
         exporter.start_exporting()
 
@@ -1086,12 +1134,8 @@ class CSVStorePipeline(BasicPipeline, PipelineWithPerSpiderMethods):
         CSVStorePipeline.rows = env.get("CSV_ROWS", allow_null=False).split(",")
 
     def open_spider(self, spider):
-        csv_file = open('output_' + spider.name + '.csv', 'w', newline='')
-        spamwriter = csv.writer(
-            csv_file,
-            delimiter=',',
-            quotechar='"',
-            quoting=csv.QUOTE_MINIMAL)
+        csv_file = open("output_" + spider.name + ".csv", "w", newline="")
+        spamwriter = csv.writer(csv_file, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
 
         spamwriter.writerow(self.rows)
         self.files[spider.name] = csv_file
@@ -1100,14 +1144,14 @@ class CSVStorePipeline(BasicPipeline, PipelineWithPerSpiderMethods):
     @staticmethod
     def get_value(item, value):
         container = item
-        tokens = value.split('.')
+        tokens = value.split(".")
         for v in tokens:
             if v in container:
                 container = container[v]
             else:
                 return None
-        if tokens[0] == 'valuespaces':
-            return list(map(lambda x: Valuespaces.findKey(tokens[1], x)['prefLabel']['de'], container))
+        if tokens[0] == "valuespaces":
+            return list(map(lambda x: Valuespaces.findKey(tokens[1], x)["prefLabel"]["de"], container))
         return container
 
     def close_spider(self, spider):
@@ -1126,9 +1170,11 @@ class EduSharingStorePipeline(EduSharing, BasicPipeline):
         self.counter = 0
 
     def open_spider(self, spider):
-        logging.debug("Entering EduSharingStorePipeline...\n"
-                      "Checking if 'crawler source template' ('Quellendatensatz-Template') should be used "
-                      "(see: 'EDU_SHARING_SOURCE_TEMPLATE_ENABLED' .env setting)...")
+        logging.debug(
+            "Entering EduSharingStorePipeline...\n"
+            "Checking if 'crawler source template' ('Quellendatensatz-Template') should be used "
+            "(see: 'EDU_SHARING_SOURCE_TEMPLATE_ENABLED' .env setting)..."
+        )
         est_enabled: bool = env.get_bool("EDU_SHARING_SOURCE_TEMPLATE_ENABLED", allow_null=True, default=False)
         # defaults to False for backwards-compatibility.
         # (The EduSharingSourceTemplateHelper class is explicitly set to throw errors and abort a crawl if this setting
@@ -1141,12 +1187,16 @@ class EduSharingStorePipeline(EduSharing, BasicPipeline):
             whitelisted_properties: dict | None = est_helper.get_whitelisted_metadata_properties()
             if whitelisted_properties:
                 setattr(spider, "edu_sharing_source_template_whitelist", whitelisted_properties)
-                logging.debug(f"Edu-sharing source template retrieval was successful. "
-                              f"The following metadata properties will be whitelisted for all items:\n"
-                              f"{whitelisted_properties}")
+                logging.debug(
+                    f"Edu-sharing source template retrieval was successful. "
+                    f"The following metadata properties will be whitelisted for all items:\n"
+                    f"{whitelisted_properties}"
+                )
             else:
-                logging.error(f"Edu-Sharing Source Template retrieval failed. "
-                              f"(Does a 'Quellendatensatz' exist in the edu-sharing repository for this spider?)")
+                logging.error(
+                    f"Edu-Sharing Source Template retrieval failed. "
+                    f"(Does a 'Quellendatensatz' exist in the edu-sharing repository for this spider?)"
+                )
         else:
             log.debug(f"Edu-Sharing Source Template feature is NOT ENABLED. Continuing EduSharingStorePipeline...")
 
@@ -1291,16 +1341,16 @@ class LisumPipeline(BasicPipeline):
         # eafCodes in this list are used as keys in
         # https://github.com/openeduhub/oeh-metadata-vocabs/blob/master/discipline.ttl
         # but are not part of the (standard) http://agmud.de/wp-content/uploads/2021/09/eafsys.txt
-        '04010',  # OEH: "Körperpflege" <-> eafCode 04010: "Mechatronik"
-        '20090',  # OEH: "Esperanto" <-> eafCode: 20080
-        '44099',  # "Open Educational Resources"
-        '64018',  # "Nachhaltigkeit"
-        '72001',  # "Zeitgemäße Bildung"
-        '900',  # Medienbildung
-        '999',  # Sonstiges
-        'niederdeutsch',
-        'oeh01',  # "Arbeit, Ernährung, Soziales"
-        'oeh04010'  # OEH: "Mechatronik" <-> eafCode: 04010 (Mechatronik)
+        "04010",  # OEH: "Körperpflege" <-> eafCode 04010: "Mechatronik"
+        "20090",  # OEH: "Esperanto" <-> eafCode: 20080
+        "44099",  # "Open Educational Resources"
+        "64018",  # "Nachhaltigkeit"
+        "72001",  # "Zeitgemäße Bildung"
+        "900",  # Medienbildung
+        "999",  # Sonstiges
+        "niederdeutsch",
+        "oeh01",  # "Arbeit, Ernährung, Soziales"
+        "oeh04010",  # OEH: "Mechatronik" <-> eafCode: 04010 (Mechatronik)
     ]
 
     EDUCATIONALCONTEXT_TO_LISUM = {
@@ -1356,8 +1406,8 @@ class LisumPipeline(BasicPipeline):
                 # this eafCode (key) gets mapped to Lisum specific B-B shorthands like "C-MA"
                 if discipline_list:
                     for discipline_w3id in discipline_list:
-                        discipline_eaf_code: str = discipline_w3id.split(sep='/')[-1]
-                        eaf_code_digits_only_regex: re.Pattern = re.compile(r'\d{3,}')
+                        discipline_eaf_code: str = discipline_w3id.split(sep="/")[-1]
+                        eaf_code_digits_only_regex: re.Pattern = re.compile(r"\d{3,}")
                         match discipline_eaf_code in self.DISCIPLINE_TO_LISUM_SHORTHAND:
                             case True:
                                 discipline_lisum_keys.add(self.DISCIPLINE_TO_LISUM_SHORTHAND.get(discipline_eaf_code))
@@ -1372,8 +1422,10 @@ class LisumPipeline(BasicPipeline):
                             case _:
                                 # due to having the 'custom'-field as a (raw) list of all eafCodes, this mainly serves
                                 # the purpose of reminding us if a 'discipline'-value couldn't be mapped to Lisum
-                                log.debug(f"LisumPipeline failed to map from eafCode {discipline_eaf_code} "
-                                          f"to its corresponding 'ccm:taxonid' short-handle. Trying Fallback...")
+                                log.debug(
+                                    f"LisumPipeline failed to map from eafCode {discipline_eaf_code} "
+                                    f"to its corresponding 'ccm:taxonid' short-handle. Trying Fallback..."
+                                )
                         match discipline_eaf_code:
                             # catching edge-cases where OEH 'discipline'-vocab-keys don't line up with eafsys.txt values
                             case "320":
@@ -1386,25 +1438,33 @@ class LisumPipeline(BasicPipeline):
                                 discipline_eafcodes.add("2600103")  # Körperpflege
                         if eaf_code_digits_only_regex.search(discipline_eaf_code):
                             # each numerical eafCode must have a length of (minimum) 3 digits to be considered valid
-                            log.debug(f"LisumPipeline: Writing eafCode {discipline_eaf_code} to buffer. (Wil be "
-                                      f"used later for 'ccm:taxonentry').")
+                            log.debug(
+                                f"LisumPipeline: Writing eafCode {discipline_eaf_code} to buffer. (Wil be "
+                                f"used later for 'ccm:taxonentry')."
+                            )
                             if discipline_eaf_code not in self.EAFCODE_EXCLUSIONS:
                                 # making sure to only save eafCodes that are part of the standard eafsys.txt
                                 discipline_eafcodes.add(discipline_eaf_code)
                             else:
-                                log.debug(f"LisumPipeline: eafCode {discipline_eaf_code} is not part of 'EAF "
-                                          f"Sachgebietssystematik' (see: eafsys.txt), therefore skipping this "
-                                          f"value.")
+                                log.debug(
+                                    f"LisumPipeline: eafCode {discipline_eaf_code} is not part of 'EAF "
+                                    f"Sachgebietssystematik' (see: eafsys.txt), therefore skipping this "
+                                    f"value."
+                                )
                         else:
                             # our 'discipline.ttl'-vocab holds custom keys (e.g. 'niederdeutsch', 'oeh04010') which
                             # shouldn't be saved into 'ccm:taxonentry' (since they are not part of the regular
                             # "EAF Sachgebietssystematik"
-                            log.debug(f"LisumPipeline eafCode fallback for {discipline_eaf_code} to "
-                                      f"'ccm:taxonentry' was not possible. Only eafCodes with a minimum length "
-                                      f"of 3+ digits are valid. (Please confirm if the provided value is part of "
-                                      f"the 'EAF Sachgebietssystematik' (see: eafsys.txt))")
-                log.debug(f"LisumPipeline: Mapping discipline values from \n {discipline_list} \n to "
-                          f"LisumPipeline: discipline_lisum_keys \n {discipline_lisum_keys}")
+                            log.debug(
+                                f"LisumPipeline eafCode fallback for {discipline_eaf_code} to "
+                                f"'ccm:taxonentry' was not possible. Only eafCodes with a minimum length "
+                                f"of 3+ digits are valid. (Please confirm if the provided value is part of "
+                                f"the 'EAF Sachgebietssystematik' (see: eafsys.txt))"
+                            )
+                log.debug(
+                    f"LisumPipeline: Mapping discipline values from \n {discipline_list} \n to "
+                    f"LisumPipeline: discipline_lisum_keys \n {discipline_lisum_keys}"
+                )
                 valuespaces["discipline"] = list()  # clearing 'discipline'-field, so we don't accidentally write the
                 # remaining OEH w3id-URLs to Lisum's 'ccm:taxonid'-field
 
@@ -1417,15 +1477,18 @@ class LisumPipeline(BasicPipeline):
                     # up until this point, every educationalContext entry will be a w3id link, e.g.
                     # 'http://w3id.org/openeduhub/vocabs/educationalContext/grundschule'
                     for educational_context_w3id in educational_context_list:
-                        educational_context_w3id_key = educational_context_w3id.split(sep='/')[-1]
+                        educational_context_w3id_key = educational_context_w3id.split(sep="/")[-1]
                         match educational_context_w3id_key in self.EDUCATIONALCONTEXT_TO_LISUM:
                             case True:
                                 educational_context_w3id_key = self.EDUCATIONALCONTEXT_TO_LISUM.get(
-                                    educational_context_w3id_key)
+                                    educational_context_w3id_key
+                                )
                                 educational_context_lisum_keys.add(educational_context_w3id_key)
                             case _:
-                                log.debug(f"LisumPipeline: educationalContext {educational_context_w3id_key} "
-                                          f"not found in mapping table.")
+                                log.debug(
+                                    f"LisumPipeline: educationalContext {educational_context_w3id_key} "
+                                    f"not found in mapping table."
+                                )
                 educational_context_list = list(educational_context_lisum_keys)
                 educational_context_list.sort()
                 valuespaces["educationalContext"] = educational_context_list
@@ -1435,7 +1498,7 @@ class LisumPipeline(BasicPipeline):
                 intended_end_user_roles = set()
                 if intended_end_user_role_list:
                     for item_w3id in intended_end_user_role_list:
-                        item_w3id: str = item_w3id.split(sep='/')[-1]
+                        item_w3id: str = item_w3id.split(sep="/")[-1]
                         if item_w3id:
                             intended_end_user_roles.add(item_w3id)
                     intended_end_user_role_list = list(intended_end_user_roles)
@@ -1452,7 +1515,7 @@ class LisumPipeline(BasicPipeline):
                             # during transformation from Sodix to OEH
                             lrt_multivalue = list()
                             for lrt_string in lrt_item:
-                                lrt_string = lrt_string.split(sep='/')[-1]
+                                lrt_string = lrt_string.split(sep="/")[-1]
                                 if lrt_string in self.LRT_OEH_TO_LISUM:
                                     lrt_string = self.LRT_OEH_TO_LISUM.get(lrt_string)
                                 if lrt_string:
@@ -1460,7 +1523,7 @@ class LisumPipeline(BasicPipeline):
                                     lrt_multivalue.append(lrt_string)
                             lrt_temporary_list.append(lrt_multivalue)
                         if type(lrt_item) is str:
-                            lrt_w3id: str = lrt_item.split(sep='/')[-1]
+                            lrt_w3id: str = lrt_item.split(sep="/")[-1]
                             if lrt_w3id in self.LRT_OEH_TO_LISUM:
                                 lrt_w3id = self.LRT_OEH_TO_LISUM.get(lrt_w3id)
                             if lrt_w3id and type(lrt_w3id) is str:
@@ -1519,8 +1582,6 @@ class LisumPipeline(BasicPipeline):
                     # 'discipline'-vocabulary-keys.
                     discipline_eafcodes_list = list(discipline_eafcodes)
                     log.debug(f"LisumPipeline: Saving eafCodes {discipline_eafcodes_list} to 'ccm:taxonentry'.")
-                    base_item_adapter.update(
-                        {'custom': {
-                            'ccm:taxonentry': discipline_eafcodes_list}})
+                    base_item_adapter.update({"custom": {"ccm:taxonentry": discipline_eafcodes_list}})
                     base_item_adapter["custom"]["ccm:taxonentry"] = discipline_eafcodes_list
         return item

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -988,6 +988,15 @@ class EduSharingTypeValidationPipeline(BasicPipeline):
                     keywords: list[str] | set[str] | None = lom_general["keyword"]
                     if keywords and isinstance(keywords, set):
                         lom_general["keyword"] = list(keywords)
+            if "technical" in item_adapter["lom"]:
+                lom_technical: dict = item_adapter["lom"]["technical"]
+                if "duration" in lom_technical:
+                    duration: int | str | None = lom_technical["duration"]
+                    # after already passing through the ConvertTimePipeline,
+                    # the duration value should be an Integer (seconds)
+                    if duration and isinstance(duration, int):
+                        # the edu-sharing API expects values to be wrapped in a string
+                        lom_technical["duration"] = str(duration)
         return item
 
 


### PR DESCRIPTION
This PR includes the following changes:
- feat: improve robustness of website screenshot fallback in thumbnail pipeline for edge-cases when neither thumbnail URL nor website URL is available for parsing via headless browser
  - this edge-case typically happened during crawls of large datasets (e.g. `sodix_spider`) under two circumstances:
    - the item itself did **not provide a valid (or reachable) `thumbnail` URL**, therefore the pipeline tried to fall back to a website screenshot
    - when the first URL in LOM Technical `location` (`cclom:location`) would point towards a binary file (e.g. `.mp3` or `.mp4`), the headless browser wouldn't be able to render / take a website screenshot either, causing an `AttributeError` Exception when trying to access the `screenshot_bytes`-object (expected type: `bytes`, but received `None`)
  - future crawls should handle these edge-cases more gracefully and try a **second fallback** if a **second** URL was stored within LOM Technical `location`
    - if neither fallback 1 nor 2 were successful, the item will be uploaded without a thumbnail
- fix: several fixes for `pydantic` `ValidationError`s during POST requests to edu-sharing
  - LOM Technical `duration`: `int` values are wrapped in a string before submitting the item
  - `BaseItem.hash`: making sure that (old) crawlers which returned an `int`-value in `getHash()` are typecast to `str` before submitting the item
  - LOM General `aggregationLevel`: `int` values are wrapped in a string before submitting the item
- fix: add missing `license.internal` mapping for `"NONPUBLIC"` license values
- style: code formatting via black to increase readability of `pipelines.py`