### PR TITLE
feat: parse robots.txt for AI usage indicators ("ccm:ai_allow_usage")

### DIFF
--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -584,6 +584,13 @@ class EduSharing:
                 if "toRange" in tar:
                     spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
 
+        if "ai_allow_usage" in item:
+            # this property is automatically filled by the RobotsTxtPipeline
+            if isinstance(item["ai_allow_usage"], bool):
+                _ai_allow_usage: bool = item["ai_allow_usage"]
+                # the edu-sharing API client expects the value to be of type string
+                spaces["ccm:ai_allow_usage"] = str(_ai_allow_usage)
+
         if "course" in item:
             if "course_availability_from" in item["course"]:
                 # as of 2024-05-14: "ccm:oeh_event_begin" expects a datetime value

--- a/converter/es_connector.py
+++ b/converter/es_connector.py
@@ -583,6 +583,14 @@ class EduSharing:
                     spaces["ccm:educationaltypicalagerange_from"] = tar["fromRange"]
                 if "toRange" in tar:
                     spaces["ccm:educationaltypicalagerange_to"] = tar["toRange"]
+            if "typicalLearningTime" in item["lom"]["educational"]:
+                tlt: int | str | None = item["lom"]["educational"]["typicalLearningTime"]
+                if (
+                        tlt and isinstance(tlt,str) and tlt.isnumeric()
+                        or tlt and isinstance(tlt, int)
+                ):
+                    tlt_in_ms: int = int(tlt) * 1000
+                    spaces["cclom:typicallearningtime"] = tlt_in_ms
 
         if "ai_allow_usage" in item:
             # this property is automatically filled by the RobotsTxtPipeline

--- a/converter/items.py
+++ b/converter/items.py
@@ -337,6 +337,7 @@ class CourseItem(Item):
     """
     BIRD-specific metadata properties intended only for courses.
     """
+
     course_availability_from = Field()
     """Corresponding edu-sharing property: ``ccm:oeh_event_begin`` (expects ISO datetime string)"""
     course_availability_until = Field()
@@ -380,6 +381,9 @@ class BaseItem(Item):
     - ``ValuespaceItem``
     """
 
+    ai_allow_usage = Field()
+    """Stores a ``bool``-value to keep track of items that are allowed to be used in AI training. 
+    Corresponding edu-sharing property: ``ccm:ai_allow_usage``"""
     binary = Field()
     """Binary data which should be uploaded to edu-sharing (= raw data, e.g. ".pdf"-files)."""
     collection = Field(output_processor=JoinMultivalues())

--- a/converter/pipelines.py
+++ b/converter/pipelines.py
@@ -347,7 +347,6 @@ class ConvertTimePipeline(BasicPipeline):
             tll_duration_in_seconds = determine_duration_and_convert_to_seconds(
                 time_raw=tll_raw, item_field_name="LomEducationalItem.typicalLearningTime"
             )
-            # ToDo: update es_connector and connect this property with the backend
             item["lom"]["educational"]["typicalLearningTime"] = tll_duration_in_seconds
 
         if "technical" in item["lom"]:

--- a/converter/settings.py
+++ b/converter/settings.py
@@ -128,6 +128,7 @@ ITEM_PIPELINES = {
     "converter.pipelines.NormLanguagePipeline": 150,
     "converter.pipelines.ConvertTimePipeline": 200,
     "converter.pipelines.ProcessValuespacePipeline": 250,
+    "converter.pipelines.RobotsTxtPipeline": 255,
     "converter.pipelines.CourseItemPipeline": 275,
     "converter.pipelines.ProcessThumbnailPipeline": 300,
     "converter.pipelines.EduSharingTypeValidationPipeline": 325,

--- a/converter/spiders/sample_spider_alternative.py
+++ b/converter/spiders/sample_spider_alternative.py
@@ -70,6 +70,8 @@ class SampleSpiderAlternative(CrawlSpider, LomBase):
         #                                   human readable string of text) store its within the 'fulltext' field.)
         #                                   If no 'fulltext' value was provided, the pipelines will try to fetch
         #                                   'full text' content from "ResponseItem.text" and save it here.
+        #  - ai_allow_usage     optional    (filled automatically by the ``RobotsTxtPipeline`` and expects a boolean)
+        #                                   indicates if an item is allowed to be used in AI training.
         base.add_value('sourceId', response.url)
         # if the source doesn't have a "datePublished" or "lastModified"-value in its header or JSON_LD,
         # you might have to help yourself with a unique string consisting of the datetime of the crawl + self.version

--- a/converter/util/robots_txt.py
+++ b/converter/util/robots_txt.py
@@ -29,7 +29,7 @@ AI_USER_AGENTS: list[str] = [
 # ToDo: the list of known AI user agents could be refactored into a SkoHub Vocab
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=512)
 def fetch_robots_txt(url: str) -> str | None:
     """
     Fetch the robots.txt file from the given URL.

--- a/converter/util/robots_txt.py
+++ b/converter/util/robots_txt.py
@@ -68,7 +68,7 @@ def _remove_wildcard_user_agent_from_robots_txt(robots_txt: str) -> str:
     _wildcard_agent_match: re.Match | None = _wildcard_pattern.search(robots_txt)
     if _wildcard_agent_match:
         # remove the wildcard user agent from the parsed robots.txt string
-        robots_txt_without_wildcard_agent: str = robots_txt.replace(_wildcard_agent_match.string, "")
+        robots_txt_without_wildcard_agent: str = robots_txt.replace(_wildcard_agent_match.group(), "")
         return robots_txt_without_wildcard_agent
     else:
         # if no wildcard user agent was detected, do nothing.

--- a/converter/util/robots_txt.py
+++ b/converter/util/robots_txt.py
@@ -1,0 +1,133 @@
+from functools import lru_cache
+
+import requests
+import tldextract
+from loguru import logger
+from protego import Protego
+from tldextract.tldextract import ExtractResult
+
+AI_USER_AGENTS: list[str] = [
+    "anthropic-ai",
+    "Claude-Web",
+    "Applebot-Extended",
+    "Bytespider",
+    "CCBot",
+    "ChatGPT-User",
+    "cohere-ai",
+    "Diffbot",
+    "FacebookBot",
+    "GoogleOther",
+    "Google-Extended",
+    "GPTBot",
+    "ImagesiftBot",
+    "PerplexityBot",
+    "OmigiliBot",
+    "Omigili",
+]
+# this non-exhaustive list of known (AI) web crawlers is used to check if the robots.txt file explicitly allows or forbids AI usage
+# for reference: https://www.foundationwebdev.com/2023/11/which-web-crawlers-are-associated-with-ai-crawlers/
+# ToDo: the list of known AI user agents could be refactored into a SkoHub Vocab
+
+
+@lru_cache(maxsize=128)
+def fetch_robots_txt(url: str) -> str | None:
+    """
+    Fetch the robots.txt file from the given URL.
+
+    :param url: URL string pointing towards a ``robots.txt``-file.
+    :return: The file content of the ``robots.txt``-file as a ``str``, otherwise returns ``None`` if the HTTP ``GET``-request failed.
+    """
+    response: requests.Response = requests.get(url=url)
+    if response.status_code != 200:
+        logger.warning(
+            f"Could not fetch robots.txt from {url} . "
+            f"Response code: {response.status_code} "
+            f"Reason: {response.reason}"
+        )
+        return None
+    else:
+        # happy-case: the content of the robots.txt file should be available in response.text
+        return response.text
+
+
+def _parse_robots_txt_with_protego(robots_txt: str) -> Protego | None:
+    """
+    Parse a ``robots.txt``-string with ``Protego``.
+
+    :param robots_txt: text content of a ``robots.txt``-file
+    :return: returns a ``Protego``-object if the string could be parsed successfully, otherwise returns ``None``
+    """
+    if robots_txt and isinstance(robots_txt, str):
+        protego_object: Protego = Protego.parse(robots_txt)
+        return protego_object
+    else:
+        return None
+
+
+def _check_protego_object_against_list_of_known_ai_user_agents(protego_object: Protego, url: str) -> bool:
+    """
+    Check if the given ``url`` is allowed to be scraped by AI user agents.
+
+    :param protego_object: ``Protego``-object holding ``robots.txt``-information
+    :param url: URL to be checked against a list of known AI user agents
+    :return: Returns ``True`` if the given ``url`` is allowed to be scraped by AI user agents. If the ``robots.txt``-file forbids AI scrapers, returns ``False``.
+    """
+    if url is None:
+        raise ValueError(f"url cannot be None. (Please provide a valid URL string!)")
+    if protego_object is None:
+        raise ValueError(f"This method requires a valid protego object.")
+    else:
+        ai_usage_allowed: bool = True  # assumption: if not explicitly disallowed by the robots.txt, AI usage is allowed
+        for user_agent in AI_USER_AGENTS:
+            _allowed_for_current_user_agent: bool = protego_object.can_fetch(
+                url=url,
+                user_agent=user_agent,
+            )
+            if _allowed_for_current_user_agent is False:
+                ai_usage_allowed = False
+                # as soon as one AI user agent is disallowed, we assume that AI usage is generally disallowed,
+                # therefore, we can skip the rest of the iterations.
+                break
+        return ai_usage_allowed
+
+
+def is_ai_usage_allowed(url: str, robots_txt: str = None) -> bool:
+    """
+    Check if the given ``url`` is allowed to be scraped by AI user agents.
+
+    :param url: URL to be checked against a list of known AI user agents
+    :param robots_txt: string value of a ``robots.txt`` file. If no ``robots.txt``-string is provided, fallback to HTTP Request: ``https://<fully_qualified_domain_name>/robots.txt``
+    :return: Returns ``True`` if the given ``url`` is allowed to be scraped by AI user agents. If the URL target forbids any of the known AI scrapers, returns ``False``.
+    """
+    if robots_txt is None:
+        # Fallback:
+        # if no robots_txt string was provided, fetch the file from "<fully qualified domain name>/robots.txt"
+        _extracted: ExtractResult = tldextract.extract(url=url)
+        # using tldextract instead of python's built-in ``urllib.parse.urlparse()``-method was a conscious decision!
+        # tldextract is more forgiving/reliable when it comes to incomplete urls (and provides a neat "fqdn"-attribute)
+        if _extracted.fqdn:
+            # use the fully qualified domain name to build the robots.txt url
+            _most_probable_robots_url_path: str = f"https://{_extracted.fqdn}/robots.txt"
+            robots_txt: str = fetch_robots_txt(url=_most_probable_robots_url_path)
+            if robots_txt is None:
+                # if the website provides no robots.txt, assume that everything is allowed
+                return True
+        else:
+            # this covers edge-cases for completely malformed URLs like "https://fakeurl"
+            raise ValueError(f"The URL {url} does not exist (and therefore contains no robots.txt).")
+    if robots_txt:
+        # happy case: check the current url against the provided robots.txt ruleset
+        po = _parse_robots_txt_with_protego(robots_txt=robots_txt)
+        _ai_usage_allowed: bool = _check_protego_object_against_list_of_known_ai_user_agents(
+            protego_object=po,
+            url=url,
+        )
+        return _ai_usage_allowed
+
+
+if __name__ == "__main__":
+    logger.info("Fetching robots.txt...")
+    # ToDo:
+    #  - implement a re-usable LomBase method (-> check against response.url for each item)
+    #  - implement this function as a pipeline?
+    pass

--- a/converter/util/robots_txt.py
+++ b/converter/util/robots_txt.py
@@ -124,10 +124,3 @@ def is_ai_usage_allowed(url: str, robots_txt: str = None) -> bool:
         )
         return _ai_usage_allowed
 
-
-if __name__ == "__main__":
-    logger.info("Fetching robots.txt...")
-    # ToDo:
-    #  - implement a re-usable LomBase method (-> check against response.url for each item)
-    #  - implement this function as a pipeline?
-    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -1009,6 +1009,24 @@ build = ["build", "twine"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "loguru"
+version = "0.7.2"
+description = "Python logging made (stupidly) simple"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "loguru-0.7.2-py3-none-any.whl", hash = "sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb"},
+    {file = "loguru-0.7.2.tar.gz", hash = "sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
+
+[[package]]
 name = "lxml"
 version = "5.3.0"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
@@ -1783,13 +1801,13 @@ requests = ">=2.32.3"
 
 [[package]]
 name = "pytest"
-version = "8.3.3"
+version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
-    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
 ]
 
 [package.dependencies]
@@ -2344,6 +2362,20 @@ files = [
 test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
+[[package]]
 name = "xmltodict"
 version = "0.14.2"
 description = "Makes working with XML feel like you are working with JSON"
@@ -2411,4 +2443,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "fc16f2a94d9a847adfedeb6e25d01cf6c70eee17ba2d4f32e5c4c8373639b6f7"
+content-hash = "9ec0fb6629691d0bc93a0e85b737abdd4f46b81d0387675a38ce4bca06c445f1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2443,4 +2443,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "9ec0fb6629691d0bc93a0e85b737abdd4f46b81d0387675a38ce4bca06c445f1"
+content-hash = "cd8a633a00ddb7d4e1a8cd526f396e6220559105d39df68f3dc9ce9b09ae2483"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ readme = "Readme.md"
 packages = [{include = "converter"}]
 
 [tool.poetry.dependencies]
+# see: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml
 python = "^3.12"
 wheel = "0.45.1"
 black = "^24.10.0"
@@ -90,8 +91,8 @@ httpx = "0.28"
 async-lru = "2.0.4"
 urllib3 = "^2.2.2"
 beautifulsoup4 = "^4.12.3"
-
-# see: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml
+loguru = "^0.7.2"
+protego = "^0.3.1"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ urllib3 = "^2.2.2"
 beautifulsoup4 = "^4.12.3"
 loguru = "^0.7.2"
 protego = "^0.3.1"
+tldextract = "^5.1.3"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q"

--- a/tests/test_language_mapper.py
+++ b/tests/test_language_mapper.py
@@ -1,8 +1,6 @@
-import logging
-
 import pytest
 
-from .language_mapper import LanguageMapper
+from converter.util.language_mapper import LanguageMapper
 
 
 class TestLanguageMapper:

--- a/tests/test_license_mapper.py
+++ b/tests/test_license_mapper.py
@@ -1,7 +1,7 @@
 import pytest
 
 from converter.constants import Constants
-from .license_mapper import LicenseMapper
+from converter.util.license_mapper import LicenseMapper
 
 
 class TestLicenseMapper:

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -6,19 +6,22 @@ from converter.util.robots_txt import fetch_robots_txt, is_ai_usage_allowed
 
 class MockResponseURLNotFound:
     """Mocks a ``requests.Response`` object for an unavailable URL."""
+
     status_code = 404
     reason = "Not Found"
+
     @staticmethod
     def get():
         return None
 
+
 class MockResponseAIScrapersForbidden:
     """Mocks a ``requests.Response`` for a website with a ``robots.txt``-file that forbids AI scraping.
     (This real example was found on golem.de)"""
+
     status_code = 200
     reason = "OK"
-    text = (
-        """
+    text = """
 User-agent: Twitterbot
 Disallow: /mail.php
 Disallow: /search.php
@@ -56,10 +59,11 @@ Sitemap: https://www.golem.de/gsiteindex.xml
 # golem.de may, in its discretion, permit certain automated access to certain golem.de pages.
 # If you would like to apply for permission to crawl golem.de, collect or use data, please email recht@golem.de
         """
-    )
+
     @staticmethod
     def get(*args, **kwargs):
         return MockResponseAIScrapersForbidden()
+
 
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -74,73 +78,110 @@ Sitemap: https://www.golem.de/gsiteindex.xml
 def test_fetch_robots_txt_from_wlo(test_input: str, expected: str | None):
     assert isinstance(fetch_robots_txt(test_input), str)
 
+
 def test_fetch_robots_txt(monkeypatch):
     """Mocks a ``requests.Response`` for a robots.txt file that forbids AI scrapers."""
+
     def mock_get(*args, **kwargs):
         return MockResponseAIScrapersForbidden()
+
     monkeypatch.setattr(requests, "get", mock_get)
     result = fetch_robots_txt("https://www.golem.de/robots.txt")
     assert isinstance(result, str)
 
+
 def test_fetch_robots_txt_from_an_unreachable_website_with_warning(monkeypatch):
     """Mocks a ``requests.Response`` for a website that's unreachable."""
+
     # see: https://docs.pytest.org/en/stable/how-to/monkeypatch.html#monkeypatching-returned-objects-building-mock-classes
     def mock_get(*args, **kwargs):
         return MockResponseURLNotFound()
+
     monkeypatch.setattr(requests, "get", mock_get)
     result = fetch_robots_txt("https://fake.url")
     assert result is None
 
+
 def test_if_ai_usage_is_allowed_on_malformed_url(monkeypatch):
     """Mocks a ``requests.Response`` for a malformed URL."""
+
     def mock_get(*args, **kwargs):
         return MockResponseURLNotFound()
+
     monkeypatch.setattr(requests, "get", mock_get)
     with pytest.raises(ValueError):
         # if the provided URL is malformed, we expect the function to raise a ValueError
         is_ai_usage_allowed("https://malformed-url/robots.txt")
 
+
 def test_if_ai_usage_is_allowed_on_website_without_robots_txt(monkeypatch):
     """Mocks a ``requests.Response`` for a (available) website that has no ``robots.txt``"""
+
     def mock_get(*args, **kwargs):
         return MockResponseURLNotFound()
+
     monkeypatch.setattr(requests, "get", mock_get)
     ai_usage_allowed = is_ai_usage_allowed(
         url="https://www.this-domain-does-not-exist.dev/robots.txt",
     )
     assert ai_usage_allowed is True
 
+
 def test_if_ai_usage_is_allowed_with_robots_txt_that_forbids_ai_scraping(monkeypatch):
     """Mocks a robots.txt file that explicitly forbids several AI scrapers from crawling the website."""
+
     def mock_get(*args, **kwargs):
         return MockResponseAIScrapersForbidden()
+
     monkeypatch.setattr(requests, "get", mock_get)
     ai_usage_allowed: bool = is_ai_usage_allowed(
         url="https://www.golem.de/robots.txt",
     )
     assert ai_usage_allowed is False
 
+
 # to run these tests, just comment out the ``pytest.mark.skip`` decorator
-@pytest.mark.skip(reason="These tests cause HTTP requests and should only be run on-demand within your IDE. "
-                         "They are flaky by nature and could break without notice!")
+@pytest.mark.skip(
+    reason="These tests fire HTTP requests and should only be run on-demand within your IDE for debugging purposes. "
+    "They are flaky by nature and could break without notice, therefore they are skipped in the CI/CD pipelines!"
+)
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        pytest.param("https://www.zum.de/robots.txt", True,
-                     id="ZUM.de does not forbid AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://www.dilertube.de/robots.txt", True,
-                     id="DiLerTube does not forbid AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://www.lehrer-online.de/robots.txt", True,
-                     id="Lehrer-Online does not forbid AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://www.scienceinschool.org/robots.txt", True,
-                     id="Science in School does not forbid AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://www.leifiphysik.de/robots.txt", False,
-                     id="Leifi-Physik forbids (a lot) of AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://www.golem.de/robots.txt", False,
-                     id="Golem.de forbids several AI scrapers. Last checked on: 2024-12-05"),
-        pytest.param("https://taz.de/robots.txt", False,
-                     id="taz.de forbids several AI scrapers (GPTBot, Bytespider). Last checked on: 2024-12-05"),
-    ]
+        pytest.param(
+            "https://www.zum.de/robots.txt", True, id="ZUM.de does not forbid AI scrapers. Last checked on: 2024-12-05"
+        ),
+        pytest.param(
+            "https://www.dilertube.de/robots.txt",
+            True,
+            id="DiLerTube does not forbid AI scrapers. Last checked on: 2024-12-05",
+        ),
+        pytest.param(
+            "https://www.lehrer-online.de/robots.txt",
+            True,
+            id="Lehrer-Online does not forbid AI scrapers. Last checked on: 2024-12-05",
+        ),
+        pytest.param(
+            "https://www.scienceinschool.org/robots.txt",
+            True,
+            id="Science in School does not forbid AI scrapers. Last checked on: 2024-12-05",
+        ),
+        pytest.param(
+            "https://www.leifiphysik.de/robots.txt",
+            False,
+            id="Leifi-Physik forbids (a lot) of AI scrapers. Last checked on: 2024-12-05",
+        ),
+        pytest.param(
+            "https://www.golem.de/robots.txt",
+            False,
+            id="Golem.de forbids several AI scrapers. Last checked on: 2024-12-05",
+        ),
+        pytest.param(
+            "https://taz.de/robots.txt",
+            False,
+            id="taz.de forbids several AI scrapers (GPTBot, Bytespider). Last checked on: 2024-12-05",
+        ),
+    ],
 )
 def test_if_ai_usage_is_allowed_with_live_examples(test_input: str, expected: bool):
     """This test is flaky by nature as it uses third-party ``robots.txt``-files, which might change without notice,

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -44,7 +44,7 @@ User-agent: *
 Disallow: /
 
 User-agent: anthropic-ai
-Allow: /
+Disallow: 
 
 User-agent: ChatGPT-User
 Disallow: /

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -119,3 +119,30 @@ def test_if_ai_usage_is_allowed_with_robots_txt_that_forbids_ai_scraping(monkeyp
         url="https://www.golem.de/robots.txt",
     )
     assert ai_usage_allowed is False
+
+# to run these tests, just comment out the ``pytest.mark.skip`` decorator
+@pytest.mark.skip(reason="These tests cause HTTP requests and should only be run on-demand within your IDE. "
+                         "They are flaky by nature and could break without notice!")
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        pytest.param("https://www.zum.de/robots.txt", True,
+                     id="ZUM.de does not forbid AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://www.dilertube.de/robots.txt", True,
+                     id="DiLerTube does not forbid AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://www.lehrer-online.de/robots.txt", True,
+                     id="Lehrer-Online does not forbid AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://www.scienceinschool.org/robots.txt", True,
+                     id="Science in School does not forbid AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://www.leifiphysik.de/robots.txt", False,
+                     id="Leifi-Physik forbids (a lot) of AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://www.golem.de/robots.txt", False,
+                     id="Golem.de forbids several AI scrapers. Last checked on: 2024-12-05"),
+        pytest.param("https://taz.de/robots.txt", False,
+                     id="taz.de forbids several AI scrapers (GPTBot, Bytespider). Last checked on: 2024-12-05"),
+    ]
+)
+def test_if_ai_usage_is_allowed_with_live_examples(test_input: str, expected: bool):
+    """This test is flaky by nature as it uses third-party ``robots.txt``-files, which might change without notice,
+    and should only be run when you want to debug with live examples."""
+    assert is_ai_usage_allowed(url=test_input) is expected

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -1,0 +1,121 @@
+import pytest
+import requests
+
+from converter.util.robots_txt import fetch_robots_txt, is_ai_usage_allowed
+
+
+class MockResponseURLNotFound:
+    """Mocks a ``requests.Response`` object for an unavailable URL."""
+    status_code = 404
+    reason = "Not Found"
+    @staticmethod
+    def get():
+        return None
+
+class MockResponseAIScrapersForbidden:
+    """Mocks a ``requests.Response`` for a website with a ``robots.txt``-file that forbids AI scraping.
+    (This real example was found on golem.de)"""
+    status_code = 200
+    reason = "OK"
+    text = (
+        """
+User-agent: Twitterbot
+Disallow: /mail.php
+Disallow: /search.php
+Disallow: /trackback/
+Disallow: /news/*.amp.html
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: *
+Disallow: /mail.php
+Disallow: /search.php
+Disallow: /trackback/
+
+
+Sitemap: https://www.golem.de/gsiteindex.xml
+
+# Legal notice: golem.de expressly reserves the right to use its content for commercial text and data mining (§ 44 b UrhG).
+# The use of robots or other automated means to access golem.de or collect or mine data without the express permission of golem.de is strictly prohibited.
+# golem.de may, in its discretion, permit certain automated access to certain golem.de pages.
+# If you would like to apply for permission to crawl golem.de, collect or use data, please email recht@golem.de
+        """
+    )
+    @staticmethod
+    def get(*args, **kwargs):
+        return MockResponseAIScrapersForbidden()
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        pytest.param(
+            "https://wirlernenonline.de/robots.txt",
+            str,
+            id="if WLO is reachable, this function should return a string",
+        )
+    ],
+)
+def test_fetch_robots_txt_from_wlo(test_input: str, expected: str | None):
+    assert isinstance(fetch_robots_txt(test_input), str)
+
+def test_fetch_robots_txt(monkeypatch):
+    """Mocks a ``requests.Response`` for a robots.txt file that forbids AI scrapers."""
+    def mock_get(*args, **kwargs):
+        return MockResponseAIScrapersForbidden()
+    monkeypatch.setattr(requests, "get", mock_get)
+    result = fetch_robots_txt("https://www.golem.de/robots.txt")
+    assert isinstance(result, str)
+
+def test_fetch_robots_txt_from_an_unreachable_website_with_warning(monkeypatch):
+    """Mocks a ``requests.Response`` for a website that's unreachable."""
+    # see: https://docs.pytest.org/en/stable/how-to/monkeypatch.html#monkeypatching-returned-objects-building-mock-classes
+    def mock_get(*args, **kwargs):
+        return MockResponseURLNotFound()
+    monkeypatch.setattr(requests, "get", mock_get)
+    result = fetch_robots_txt("https://fake.url")
+    assert result is None
+
+def test_if_ai_usage_is_allowed_on_malformed_url(monkeypatch):
+    """Mocks a ``requests.Response`` for a malformed URL."""
+    def mock_get(*args, **kwargs):
+        return MockResponseURLNotFound()
+    monkeypatch.setattr(requests, "get", mock_get)
+    with pytest.raises(ValueError):
+        # if the provided URL is malformed, we expect the function to raise a ValueError
+        is_ai_usage_allowed("https://malformed-url/robots.txt")
+
+def test_if_ai_usage_is_allowed_on_website_without_robots_txt(monkeypatch):
+    """Mocks a ``requests.Response`` for a (available) website that has no ``robots.txt``"""
+    def mock_get(*args, **kwargs):
+        return MockResponseURLNotFound()
+    monkeypatch.setattr(requests, "get", mock_get)
+    ai_usage_allowed = is_ai_usage_allowed(
+        url="https://www.this-domain-does-not-exist.dev/robots.txt",
+    )
+    assert ai_usage_allowed is True
+
+def test_if_ai_usage_is_allowed_with_robots_txt_that_forbids_ai_scraping(monkeypatch):
+    """Mocks a robots.txt file that explicitly forbids several AI scrapers from crawling the website."""
+    def mock_get(*args, **kwargs):
+        return MockResponseAIScrapersForbidden()
+    monkeypatch.setattr(requests, "get", mock_get)
+    ai_usage_allowed: bool = is_ai_usage_allowed(
+        url="https://www.golem.de/robots.txt",
+    )
+    assert ai_usage_allowed is False


### PR DESCRIPTION
This PR includes the following changes:
- feat: implemented a new Scrapy Field in `BaseItem`: `ai_allow_usage` 
  - this metadata field is meant to store a `bool`-value that indicates if a crawled item is allowed (or disallowed) for usage in AI training
- feat: implemented a `RobotsTxtPipeline` to automatically fill up the `BaseItem.ai_allow_usage`-Field during a crawl
- feat: connected `LomEducationalItem.typicalLearningTime` with the edu-sharing backend (`cclom:typicallearningtime`)
- deps: added `loguru`, `protego` and `tldextract` to the list of dependencies
  - [loguru](https://github.com/Delgan/loguru): to make debugging (and logging handlers) a bit more pleasant to work with
  - [protego](https://github.com/scrapy/protego): for parsing `robots.txt`-files more efficiently than the Python built-in [RobotFileParser](https://docs.python.org/3/library/urllib.robotparser.html)
    - this package is used by the Scrapy package (and maintained by the Scrapy devs)
  - [tldextract](https://github.com/john-kurkowski/tldextract): helps us with disassembling URLs into their structural parts
    - (this package is part of the Scrapy dependencies)

(This PR closes https://edu-sharing.atlassian.net/browse/KDATAPORT-23)

---

# Implementation details

The basic idea of the `ai_allow_usage`-Field and its `bool`-value:
While there is currently no strict standard that handles the question of *"is this <dataset / item> allowed to be used by AI?"*, the [robots.txt](https://www.robotstxt.org/robotstxt.html)-file of a website might at least offer some indicators that could become relevant in the future.

If a webmaster explicitly forbids some AI scrapers from interacting with his website (by declaring a `robots.txt`-directive for known AI user agents), we assume that all AI usage is **generally disallowed** for said items. Here's an excerpt of disallowed AI user agents ([this example](https://www.eoas.ubc.ca/robots.txt) is from the faculty "Department of Earth, Ocean and Atmospheric Sciences" from the University of British Columbia):

```
User-agent: anthropic-ai
Disallow: /
User-agent: Claude-Web
Disallow: /
User-agent: GPTBot
Disallow: /
```

When an item goes through our `RobotsTxtPipeline`, the pipeline compares the item's URL with the rules/directives of the parsed `robots.txt`-file and checks against a list of known AI user agents (for further reading: ["Which web crawlers are associated with AI crawlers?"](https://www.foundationwebdev.com/2023/11/which-web-crawlers-are-associated-with-ai-crawlers/)). As soon as one AI scraper is forbidden, the Pipeline will flag the item with `ai_usage_allowed: False`

If there are no (known) AI user agents mentioned in the `robots.txt`-file, we need to assume that a webmaster has not made a conscious decision yet and therefore assume that AI usage was allowed at the time of crawl. This use-case includes restrictive `robots.txt`-files like a general `disallow`-directive for robots (see: wildcard user agent `*`):

```
User-agent: *
Disallow: /
```

In this case, the pipeline would disregard the directive altogether and flag the item as `ai_usage_allowed: True`, as long as no other AI user agents are mentioned in the `robots.txt`.

## `RobotsTxtPipeline`: Cache / Performance

Crawling a big website or dataset (e.g., OERSI / SODIX) often consists of thousands of URLs (and therefore items to be crawled). To minimize the performance impact of having to fire additional HTTP `GET`-Requests towards each individual item's `https://<fully_qualified_domain_name>/robots.txt` URL, some precautions were taken with regard to caching:
To guarantee that only a single HTTP Request per fully qualified domain name is made, the `robots_txt.py`-utility uses an [LRU cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) of size 512. Once a `robots.txt`-file has been parsed, the cached `str`-value will be readily available for subsequent requests and the performance hit should be miniscule.